### PR TITLE
BlueskyScan: Use inproc socket for in-process comms to always avoid port collision

### DIFF
--- a/psdaq/psdaq/control/BlueskyScan.py
+++ b/psdaq/psdaq/control/BlueskyScan.py
@@ -11,19 +11,17 @@ import time
 import numpy as np
 
 from psdaq.control.ControlDef import ControlDef
-from psdaq.control.ControlDef import scan_pull_port
 
 class BlueskyScan:
     def __init__(self, control, *, daqState, args):
-        self.zmq_port = scan_pull_port(args.p)
         self.control = control
         self.name = 'mydaq'
         self.parent = None
         self.context = zmq.Context()
         self.push_socket = self.context.socket(zmq.PUSH)
-        self.push_socket.bind('tcp://*:%d' % self.zmq_port)
+        self.push_socket.bind('inproc://bluesky_scan')
         self.pull_socket = self.context.socket(zmq.PULL)
-        self.pull_socket.connect('tcp://localhost:%d' % self.zmq_port)
+        self.pull_socket.connect('inproc://bluesky_scan')
         self.comm_thread = threading.Thread(target=self.daq_communicator_thread, args=())
         self.mon_thread = threading.Thread(target=self.daq_monitor_thread, args=(), daemon=True)
         self.ready = threading.Event()


### PR DESCRIPTION
Separating tcp socket ports by platform as done in master fixes some of the collision issues, but collisions are still possible in certain cases.

Switching from tcp:// to inproc:// for the socket that is used solely for communication with the background thread ensures that an old python process does not prevent a new one from controlling the daq. Without this you can get an exception raised on the bind call, and you'll need to hunt down the rogue process to proceed.

I removed references to the port number that would no longer be used after this edit.