### PR TITLE
added sfx_raw_1_2_3 class in test_detectors

### DIFF
--- a/psana/psana/detector/test_detectors.py
+++ b/psana/psana/detector/test_detectors.py
@@ -341,3 +341,38 @@ class cspad_raw_1_2_3(DetectorImpl):
             geometry_access.load_pars_from_str(geometry_string)
         return geometry_access
 
+class sfx_raw_1_2_3(DetectorImpl):
+    """Test detector produced by dgrampy"""
+    def __init__(self, *args):
+        super(sfx_raw_1_2_3, self).__init__(*args)
+    def calib(self, evt) -> Array3d:
+        segs = self._segments(evt)
+        return segs[0].calib
+    def photon_energy(self, evt):
+        segs = self._segments(evt)
+        return segs[0].photon_energy
+    
+    ## peak finder
+    def npeaks(self,evt):
+        segs = self._segments(evt)
+        return segs[0].npeaks
+    def seg(self,evt):
+        segs = self._segments(evt)
+        return segs[0].seg
+    def row(self,evt):
+        segs = self._segments(evt)
+        return segs[0].row
+    def col(self,evt):
+        segs = self._segments(evt)
+        return segs[0].col
+    def npix(self,evt):
+        segs = self._segments(evt)
+        return segs[0].npix
+    def amax(self,evt):
+        segs = self._segments(evt)
+        return segs[0].amax
+    def atot(self,evt):
+        segs = self._segments(evt)
+        return segs[0].atot
+
+


### PR DESCRIPTION
sfx_raw class is needed to read/write peakfinder results in xtc2 files