### PR TITLE
replacing calib password as evironmental

### DIFF
--- a/psana/psana/pscalib/calib/CalibConstants.py
+++ b/psana/psana/pscalib/calib/CalibConstants.py
@@ -44,7 +44,7 @@ USERPW = 'pw-should-be-provided-somehow'
 DBNAME_PREFIX = 'cdb_'
 DETNAMESDB = '%sdetnames' % DBNAME_PREFIX
 MAX_DETNAME_SIZE = 55
-OPER = os.getenv('CONFIGDB_AUTH')
+OPER = os.getenv('CALIBDB_AUTH')
 
 try: KRBHEADERS = KerberosTicket("HTTP@" + urlparse(URL_KRB).hostname).getAuthHeaders()
 #except kerberos.GSSError as e:


### PR DESCRIPTION
Introducing a third password in the auth.sh file to take into account the calibration password in  mongo db