### PR TITLE
Eyescan support (XPM)

### DIFF
--- a/psdaq/psdaq/pyxpm/pyxpm_eyescan.py
+++ b/psdaq/psdaq/pyxpm/pyxpm_eyescan.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python
+
+import sys
+import time
+import pyrogue as pr
+import argparse
+import logging
+
+import rogue
+import rogue.hardware.axi
+
+import pyrogue.protocols
+import pyrogue.pydm
+import time
+
+import cameralink_gateway  # to get surf
+import surf.axi                     as axi
+
+import psdaq.pyxpm.xpm              as xpm
+
+from p4p.client.thread import Context
+
+class Top(pr.Root):
+
+    def __init__(   self,       
+                    name        = "Top",
+                    description = "Container for X",
+                    ipAddr      = 'localhost',
+                    memBase     = 0,
+                    fidPrescale = 200,
+                    **kwargs):
+        super().__init__(name=name, description=description, **kwargs)
+
+        self.zmqServer = pr.interfaces.ZmqServer(root=self, addr='*', port=0)
+        self.addInterface(self.zmqServer)
+
+        ################################################################################################################
+        # UDP_SRV_XVC_IDX_C         => 2542,  -- Xilinx XVC 
+        # UDP_SRV_SRPV0_IDX_C       => 8192,  -- Legacy SRPv0 register access (still used for remote FPGA reprogramming)
+        # UDP_SRV_RSSI0_IDX_C       => 8193,  -- Legacy Non-interleaved RSSI for Register access and ASYNC messages
+        # UDP_SRV_RSSI1_IDX_C       => 8194,  -- Legacy Non-interleaved RSSI for bulk data transfer
+        # UDP_SRV_BP_MGS_IDX_C      => 8195,  -- Backplane Messaging
+        # UDP_SRV_TIMING_IDX_C      => 8197,  -- Timing ASYNC Messaging
+        # UDP_SRV_RSSI_ILEAVE_IDX_C => 8198);  -- Interleaved RSSI         
+        ################################################################################################################
+
+        # Create SRP/ASYNC_MSG interface
+        if True:
+            # UDP only
+            self.udp = rogue.protocols.udp.Client(ipAddr,8192,0)
+            
+            # Connect the SRPv0 to RAW UDP
+            self.srp = rogue.protocols.srp.SrpV0()
+            pyrogue.streamConnectBiDir( self.srp, self.udp )
+
+        if False:
+            self.rudp = pyrogue.protocols.UdpRssiPack( name='rudpReg', host=ipAddr, port=8193, packVer = 1, jumbo = False)
+
+            # Connect the SRPv3 to tDest = 0x0
+            self.srp = rogue.protocols.srp.SrpV3()
+            pr.streamConnectBiDir( self.srp, self.rudp.application(dest=0x0) )
+
+            # Create stream interface
+            self.stream = pr.protocols.UdpRssiPack( name='rudpData', host=ipAddr, port=8194, packVer = 1, jumbo = False)
+
+        ######################################################################
+        
+        # Add devices
+        self.add(axi.AxiVersion( 
+            memBase = self.srp,
+            offset  = 0x00000000, 
+            expand  = False,
+        ))
+
+        LinksAMC0 = [ 
+                     ['Link[0]',0x80100000],
+                     ['Link[1]',0x80110000],
+                     ['Link[2]',0x80120000],
+                     ['Link[3]',0x80130000],
+                     ['Link[4]',0x80140000],
+                     ['Link[5]',0x80150000],
+                     ['Link[6]',0x80160000],
+                     ['Link[7]',0x80200000],
+                     ['Link[8]',0x80210000],
+                     ['Link[9]',0x80220000],
+                     ['Link[10]',0x80230000],
+                     ['Link[11]',0x80240000],
+                     ['Link[12]',0x80250000],
+                     ['Link[13]',0x80260000]  
+        ]
+
+
+        for i in range(len(LinksAMC0)):
+            self.add(xpm.XpmGth(
+                memBase = self.srp,
+                name   = LinksAMC0[i][0],
+                offset = LinksAMC0[i][1],
+            ))
+
+        hsrParms = [ ['HSRep[0]',0x09000000],
+                     ['HSRep[1]',0x09010000],
+                     ['HSRep[2]',0x09020000],
+                     ['HSRep[3]',0x09030000],
+                     ['HSRep[4]',0x09040000],
+                     ['HSRep[5]',0x09050000] ]
+        for i in range(len(hsrParms)):
+            self.add(xpm.Ds125br401(
+                memBase = self.srp,
+                name   = hsrParms[i][0],
+                offset = hsrParms[i][1],
+            ))
+
+        self.add(xpm.XpmApp(
+            memBase = self.srp,
+            name   = 'XpmApp',
+            offset = 0x80000000,
+            fidPrescale = fidPrescale,
+        ))
+
+def main():
+    global prefix
+    prefix = ''
+
+    parser = argparse.ArgumentParser(prog=sys.argv[0], description='host PVs for XPM')
+
+    parser.add_argument('-v', '--verbose', action='store_true', help='be verbose')
+    parser.add_argument('--ip', type=str, required=True, help="IP address" )
+    parser.add_argument('--link', type=int, required=False, help="Link identifier" )
+    parser.add_argument('--hseq', type=int, required=False, help="High speed equalizer setting" )
+    parser.add_argument('--eye', action='store_true', help='Generate eye diagram')
+    parser.add_argument('--bathtub', action='store_true', help='Generate bathtub curve')
+    parser.add_argument('--target', type=float, required=False, help="BET Target" )
+
+    args = parser.parse_args()
+    if args.verbose:
+        setVerbose(True)
+
+    if args.eye == False and args.bathtub == False:
+        print("Select at least one plot: --eye or --bathtub")
+        return
+
+    # Set base
+    base = Top(
+        name='XPM',
+        description='',
+        ipAddr = args.ip,
+    )
+
+    # Start the system
+    base.start()
+
+    hsConfig = [
+            {'dev': 0, 'ch': 3}, #AMC0 - Link 0 (link 0)
+            {'dev': 0, 'ch': 2}, #AMC0 - Link 1 (link 1)
+            {'dev': 0, 'ch': 1}, #AMC0 - Link 2 (link 2)
+            {'dev': 0, 'ch': 0}, #AMC0 - Link 3 (link 3)
+            {'dev': 1, 'ch': 3}, #AMC0 - Link 4 (link 4)
+            {'dev': 1, 'ch': 2}, #AMC0 - Link 5 (link 5)
+            {'dev': 1, 'ch': 1}, #AMC0 - Link 6 (link 6)
+            {'dev': 3, 'ch': 3}, #AMC1 - Link 0 (link 7)
+            {'dev': 3, 'ch': 2}, #AMC1 - Link 1 (link 8)
+            {'dev': 3, 'ch': 1}, #AMC1 - Link 2 (link 9)
+            {'dev': 3, 'ch': 0}, #AMC1 - Link 3 (link 10)
+            {'dev': 4, 'ch': 3}, #AMC1 - Link 4 (link 11)
+            {'dev': 4, 'ch': 2}, #AMC1 - Link 5 (link 12)
+            {'dev': 4, 'ch': 1}, #AMC1 - Link 6 (link 13)
+        ]
+
+    if args.link is None:
+        linkid = 0
+    else:
+        linkid = args.link
+
+    #GTH Config
+    base.XpmApp.link.set(linkid)
+    base.XpmApp.loopback.set(0x00)
+
+    loopback = base.XpmApp.loopback.get()
+    link_rxcdrlock = base.XpmApp.link_rxcdrlock.get()
+    link_rxpmarstdone = base.XpmApp.link_rxpmarstdone.get()
+    link_txpmarstdone = base.XpmApp.link_txResetDone.get()
+
+    if link_rxcdrlock != 0x01:
+        print("Link not locked: CDR not locked, link not connected or data quality too bad")
+        base.stop()
+        return
+
+    print('Link [{}] Loopback({}) CDRLocked ({}) RxPMARstDone ({}) TxPMARstDone ({})'.format(linkid, loopback, link_rxcdrlock, link_rxpmarstdone, link_txpmarstdone))
+
+    if args.hseq is not None:
+        #High-speed repeater config
+        device = base.HSRep[hsConfig[linkid]['dev']]
+        device.CtrlEn.set(True)
+        device.EQ_ch[hsConfig[linkid]['ch']].set(args.hseq)
+
+    if args.target is None:
+        target = 1e-8
+    else:
+        target = args.target
+
+    if args.bathtub:
+        base.Link[linkid].bathtubPlot()
+
+    if args.eye:
+        base.Link[linkid].eyePlot(target=target)
+
+    base.stop()
+
+    #pyrogue.pydm.runPyDM(
+    #    serverList  = base.zmqServer.address,
+    #    sizeX       = 800,
+    #    sizeY       = 800,
+    #)
+    
+    #base.Link[0].EyePlot()
+
+if __name__ == '__main__':
+    main()

--- a/psdaq/psdaq/pyxpm/xpm/_XpmApp.py
+++ b/psdaq/psdaq/pyxpm/xpm/_XpmApp.py
@@ -72,6 +72,7 @@ class XpmApp(pr.Device):
                     description = "XPM Module", 
                     fidPrescale = 200,
                     removeMonReg = False,
+                    linkMonitoring = False,
                     **kwargs):
         super().__init__(name=name, description=description, **kwargs)
 
@@ -272,6 +273,128 @@ class XpmApp(pr.Device):
             base         = pr.UInt,
             mode         = "RW",
         ))
+
+        if linkMonitoring:
+            self.add(pr.RemoteVariable(
+                name         = "link_txResetDone",
+                description  = "link status summary",
+                offset       =  0x50,
+                bitSize      =  1,
+                bitOffset    =  0x00,
+                base         = pr.UInt,
+                mode         = "RO",
+            ))
+
+            self.add(pr.RemoteVariable(
+                name         = "link_txReady",
+                description  = "link status summary",
+                offset       =  0x50,
+                bitSize      =  1,
+                bitOffset    =  0x01,
+                base         = pr.UInt,
+                mode         = "RO",
+            ))
+
+            self.add(pr.RemoteVariable(
+                name         = "link_rxResetDone",
+                description  = "link status summary",
+                offset       =  0x50,
+                bitSize      =  1,
+                bitOffset    =  0x02,
+                base         = pr.UInt,
+                mode         = "RO",
+            ))
+
+            self.add(pr.RemoteVariable(
+                name         = "link_rxReady",
+                description  = "link status summary",
+                offset       =  0x50,
+                bitSize      =  1,
+                bitOffset    =  0x03,
+                base         = pr.UInt,
+                mode         = "RO",
+            ))
+
+            self.add(pr.RemoteVariable(
+                name         = "link_rxErr",
+                description  = "link status summary",
+                offset       =  0x50,
+                bitSize      =  1,
+                bitOffset    =  0x04,
+                base         = pr.UInt,
+                mode         = "RO",
+            ))
+
+            self.add(pr.RemoteVariable(
+                name         = "link_rxIsXpm",
+                description  = "link status summary",
+                offset       =  0x50,
+                bitSize      =  1,
+                bitOffset    =  0x05,
+                base         = pr.UInt,
+                mode         = "RO",
+            ))
+
+            self.add(pr.RemoteVariable(
+                name         = "link_rxpmarstdone",
+                description  = "link status summary",
+                offset       =  0x50,
+                bitSize      =  1,
+                bitOffset    =  8,
+                base         = pr.UInt,
+                mode         = "RO",
+            ))
+
+            self.add(pr.RemoteVariable(
+                name         = "link_txpmarstdone",
+                description  = "link status summary",
+                offset       =  0x50,
+                bitSize      =  1,
+                bitOffset    =  9,
+                base         = pr.UInt,
+                mode         = "RO",
+            ))
+
+
+            self.add(pr.RemoteVariable(
+                name         = "link_rxcdrlock",
+                description  = "link status summary",
+                offset       =  0x50,
+                bitSize      =  1,
+                bitOffset    =  6,
+                base         = pr.UInt,
+                mode         = "RO",
+            ))
+
+            self.add(pr.RemoteVariable(
+                name         = "link_rxErrCnts",
+                description  = "link status summary",
+                offset       =  0x54,
+                bitSize      =  16,
+                bitOffset    =  0x00,
+                base         = pr.UInt,
+                mode         = "RO",
+            ))
+
+            self.add(pr.RemoteVariable(
+                name         = "link_rxRcvCnts",
+                description  = "link status summary",
+                offset       =  0x58,
+                bitSize      =  32,
+                bitOffset    =  0x00,
+                base         = pr.UInt,
+                mode         = "RO",
+            ))
+
+            self.add(pr.RemoteVariable(
+                name         = "link_rxId",
+                description  = "link status summary",
+                offset       =  0x5c,
+                bitSize      =  32,
+                bitOffset    =  0x00,
+                base         = pr.UInt,
+                mode         = "RO",
+            ))
 
         if not removeMonReg:
             self.add(pr.RemoteVariable(    

--- a/psdaq/psdaq/pyxpm/xpm/_XpmApp.py
+++ b/psdaq/psdaq/pyxpm/xpm/_XpmApp.py
@@ -406,6 +406,16 @@ class XpmApp(pr.Device):
                 mode         = "RO",
             ))
 
+            self.add(pr.RemoteVariable(
+                name         = "link_eyescanrst",
+                description  = "Reset GTH counters",
+                offset       =  0x08,
+                bitSize      =  1,
+                bitOffset    =  21,
+                base         = pr.UInt,
+                mode         = "RO",
+            ))
+
         if not removeMonReg:
             self.add(pr.RemoteVariable(    
                 name         = "dsLinkStatus",

--- a/psdaq/psdaq/pyxpm/xpm/_XpmApp.py
+++ b/psdaq/psdaq/pyxpm/xpm/_XpmApp.py
@@ -396,6 +396,16 @@ class XpmApp(pr.Device):
                 mode         = "RO",
             ))
 
+            self.add(pr.RemoteVariable(
+                name         = "link_gthCntRst",
+                description  = "Reset GTH counters",
+                offset       =  0x08,
+                bitSize      =  1,
+                bitOffset    =  22,
+                base         = pr.UInt,
+                mode         = "RO",
+            ))
+
         if not removeMonReg:
             self.add(pr.RemoteVariable(    
                 name         = "dsLinkStatus",

--- a/psdaq/psdaq/pyxpm/xpm/_XpmGth.py
+++ b/psdaq/psdaq/pyxpm/xpm/_XpmGth.py
@@ -1,0 +1,419 @@
+#-----------------------------------------------------------------------------
+# Description:
+# PyRogue Gthe3Channel
+#-----------------------------------------------------------------------------
+# This file is part of the 'SLAC Firmware Standard Library'. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the 'SLAC Firmware Standard Library', including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import pyrogue as pr
+
+import math
+import sys
+
+import time
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+class XpmGth(pr.Device):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        ##############################
+        # Variables
+        ##############################
+        self.add(pr.RemoteVariable(
+            name         = "RX_DATA_WIDTH",
+            offset       =  0x03 << 2,
+            bitSize      =  4,
+            bitOffset    =  5,
+            mode         = "RW",
+            # enum         = {
+                # 0 : '-',
+                # 2 : '16',
+                # 3 : '20',
+                # 4 : '32',
+                # 5 : '40',
+                # 6 : '64',
+                # 7 : '80',
+                # 8 : '128',
+                # 9 : '160'},
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "ES_PRESCALE",
+            offset       =  0xF0,
+            bitSize      =  5,
+            mode         = "RW",
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "ES_EYE_SCAN_EN",
+            offset       =  0xF1,
+            bitSize      =  1,
+            mode         = "RW",
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "RX_EYESCAN_VS_NEG_DIR",
+            offset       =  0x25D,
+            bitSize      =  1,
+            bitOffset    =  2,
+            mode         = "RW",
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "RX_EYESCAN_VS_UT_SIGN",
+            offset       =  0x25D,
+            bitSize      =  1,
+            bitOffset    =  1,
+            mode         = "RW",
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "RX_EYESCAN_VS_CODE",
+            offset       =  0x25C,
+            bitSize      =  7,
+            bitOffset    =  2,
+            mode         = "RW",
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "RX_EYESCAN_VS_RANGE",
+            offset       =  0x25C,
+            bitSize      =  2,
+            mode         = "RW",
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "ES_CLK_PHASE_SEL",
+            offset       =  0x251,
+            bitSize      =  1,
+            bitOffset    =  3,
+            mode         = "RW",
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "ES_PMA_CFG",
+            offset       =  0x144,
+            bitSize      =  10,
+            mode         = "RW",
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "ES_HORZ_OFFSET",
+            offset       =  0x13C,
+            bitSize      =  12,
+            bitOffset    =  4,
+            mode         = "RW",
+        ))
+
+        self.addRemoteVariables(
+            name         = "ES_SDATA_MASK",
+            offset       =  0x124,
+            bitSize      =  16,
+            mode         = "RW",
+            number       =  5,
+            stride       =  4,
+        )
+
+        self.addRemoteVariables(
+            name         = "ES_QUAL_MASK",
+            offset       =  0x110,
+            bitSize      =  16,
+            mode         = "RW",
+            number       =  5,
+            stride       =  4,
+        )
+
+        self.addRemoteVariables(
+            name         = "ES_QUALIFIER",
+            offset       =  0xFC,
+            bitSize      =  16,
+            mode         = "RW",
+            number       =  5,
+            stride       =  4,
+        )
+
+        self.add(pr.RemoteVariable(
+            name         = "ES_CONTROL",
+            offset       =  0xF1,
+            bitSize      =  6,
+            bitOffset    =  2,
+            mode         = "RW",
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "ES_ERRDET_EN",
+            offset       =  0xF1,
+            bitSize      =  1,
+            bitOffset    =  1,
+            mode         = "RW",
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "ES_CONTROL_STATUS",
+            offset       =  0x54c,
+            bitSize      =  4,
+            bitOffset    =  0,
+            mode         = "RW",
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "ES_SAMPLE_COUNT",
+            offset       =  0x548,
+            bitSize      =  16,
+            bitOffset    =  1,
+            mode         = "RW",
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "ES_ERROR_COUNT",
+            offset       =  0x544,
+            bitSize      =  16,
+            bitOffset    =  1,
+            mode         = "RW",
+        ))
+
+    def bathtubPlot(self):
+        bers = self.bathtub()
+        extrapolated = self.extrapolate(bers)
+        plt.clf()
+        plt.close()
+        plt.figure()
+
+        plt.plot(np.array(bers), color='blue', label='measurement')
+        plt.plot(np.array(extrapolated), color='blue', label='Extrapolation (random jitter)', linestyle='dashed')
+
+        plt.axvline(x=54, color="green", label="CDR Mask: 0.15UI ({})".format(54), linewidth=1)
+
+        plt.plot(54, extrapolated[54], marker="x", markersize=4, markeredgecolor="red")
+        plt.text(44, extrapolated[54], 'BER: {:.2e}'.format(extrapolated[54]), ha="center")
+
+        plt.legend()
+        plt.yscale("log")
+       
+        plt.show()
+
+    def eyePlot(self, target = 1e-4):
+        eye = self.getEye(target)
+        plt.clf()
+        plt.close()
+        plt.figure()
+
+        ypoints = np.array(eye)
+        xpoints = np.array(list(range(-64,64)) + list(reversed(range(-64,64))))
+        plt.plot(xpoints, ypoints, color='blue', label='BER: {:.2e}'.format(target))
+        plt.fill_between([-10, 0, 10, 0, -10], [0, 30, 0, -30, 0], color='green', label='CDR Mask')
+
+        plt.legend()
+        plt.show()
+
+    def extrapolate(self, bathtub):
+        log = np.array([
+            np.log(bathtub[-4]),
+            np.log(bathtub[-3]),
+            np.log(bathtub[-2]),
+            np.log(bathtub[-1]),
+        ])
+
+        x = np.array([
+            len(bathtub)-4,
+            len(bathtub)-3,
+            len(bathtub)-2,
+            len(bathtub)-1,
+        ])
+
+        p = np.poly1d(np.polyfit(x, log, 1))
+        
+        extrapolated = []
+        for i in range(64):
+            extrapolated.append(1 if np.exp(p(i)) > 1 else np.exp(p(i)))
+
+        return extrapolated
+
+
+    def bathtub(self):
+        y = 0
+        bers = []
+
+        for pos in range(-64, 0):
+            ber = self.getBER(1e-9, pos, y)
+            if ber != 0:
+                bers.append(ber)
+            else:
+                break
+
+            #print("[{}] {}".format(64-pos, ber))
+
+        return bers
+
+    def getEye(self, target = 1e-4):
+        start = time.time()
+
+        positiveY = []
+        negativeY = []
+
+        ber = -1
+        y = 0
+
+        for pos in range(-64, 64):
+            prev = ber
+
+            currY = []
+            while True:
+
+                if y in currY:
+                    positiveY.append(y)
+                    break
+
+                currY.append(y)
+                ber = self.getBER(target, pos, y)
+
+                if ber > target:
+                    y -= 2 if pos < 0 else 10
+                else:
+                    y += 2 if pos > 0 else 10
+
+                if y < 0:
+                    y = 0
+                    positiveY.append(0)
+                    break
+
+                if y > 127:
+                    y = 127
+                    positiveY.append(127)
+                    break
+
+                if prev <= target and ber > target:
+                    positiveY.append(y+2)
+                    break
+
+                if prev <= target and ber < target:
+                    positiveY.append(y-2)
+                    break
+
+        print("NEGATIVE")
+        ber = -1
+        y = 0
+
+        for pos in range(-64, 64):
+            prev = ber
+
+            currY = []
+            while True:
+
+                if y in currY:
+                    negativeY.append(y)
+                    break
+
+                currY.append(y)
+                ber = self.getBER(target, pos, y)
+
+                if ber > target:
+                    y += 1 if pos < 0 else 10
+                else:
+                    y -= 1 if pos > 0 else 10
+
+                if y < -127:
+                    y = -127
+                    negativeY.append(-127)
+                    break
+
+                if y > 0:
+                    y = 0
+                    negativeY.append(0)
+                    break
+
+                if prev <= target and ber > target:
+                    negativeY.append(y-2)
+                    break
+
+                if prev <= target and ber < target:
+                    negativeY.append(y+2)
+                    break
+
+        print("Eyepos generated in {}".format(time.time()-start))
+
+        ret = positiveY
+        negativeY.reverse()
+        ret.extend(negativeY)
+
+        return ret
+
+    def getBER(self, berTarget, x, y):
+        bitCntTarget = 1/berTarget
+
+        prescaler = 0
+        while True:
+            if prescaler == 32:
+                raise Exception('BER to high')
+
+            if 20*math.pow(2, 1+prescaler)*32768 < bitCntTarget*2:
+                prescaler += 1
+
+            else:
+                break
+
+        self.ES_EYE_SCAN_EN.set(0x01)
+        self.ES_ERRDET_EN.set(0x01)
+
+        self.ES_PRESCALE.set(prescaler)
+
+        self.ES_SDATA_MASK[0].set(0x0000)
+        self.ES_SDATA_MASK[1].set(0x0000)
+        self.ES_SDATA_MASK[2].set(0xff00)
+        self.ES_SDATA_MASK[3].set(0xffff)
+        self.ES_SDATA_MASK[4].set(0xffff)
+
+        for i in range(len(self.ES_QUAL_MASK)):
+            self.ES_QUAL_MASK[i].set(0xffff)
+        
+        self.RX_EYESCAN_VS_RANGE.set(0x00)
+        self.ES_CONTROL.set(0x00)
+
+        if y > 0:
+            self.RX_EYESCAN_VS_NEG_DIR.set(0x00)
+            self.RX_EYESCAN_VS_UT_SIGN.set(0x01)
+            self.RX_EYESCAN_VS_CODE.set(y)
+        else:
+            self.RX_EYESCAN_VS_NEG_DIR.set(0x00)
+            self.RX_EYESCAN_VS_UT_SIGN.set(0x00)
+            self.RX_EYESCAN_VS_CODE.set(-1*y)
+
+        if x < 0:
+            tmp = 0xFFF & x
+            self.ES_HORZ_OFFSET.set(tmp)
+        else:
+            self.ES_HORZ_OFFSET.set(x)
+
+        status = self.ES_CONTROL_STATUS.get()
+        while (status & 0x0e) != 0:
+            status = self.ES_CONTROL_STATUS.get()
+            #print("Wait for ready status: {}".format(status))
+
+        self.ES_CONTROL.set(0x01)
+        status = self.ES_CONTROL_STATUS.get()
+
+        while not (status & 0x01):
+            status = self.ES_CONTROL_STATUS.get()
+
+        errCount = self.ES_ERROR_COUNT.get()
+        sampleCount = self.ES_SAMPLE_COUNT.get()
+        bitCount = 20*math.pow(2, 1+prescaler)*sampleCount
+
+        print('[{}/{}] Err = {}, Bit = {}'.format(x,y, errCount, bitCount))
+
+        if bitCount == 0:
+            return 1
+
+        #Sample count to bit = 20*2^(1+prescaler)*sampleCount
+        ber = float(errCount)/float(bitCount)
+
+        return ber

--- a/psdaq/psdaq/pyxpm/xpm/_XpmGth.py
+++ b/psdaq/psdaq/pyxpm/xpm/_XpmGth.py
@@ -210,7 +210,7 @@ class XpmGth(pr.Device):
         ypoints = np.array(eye)
         xpoints = np.array(list(range(-64,64)) + list(reversed(range(-64,64))))
         plt.plot(xpoints, ypoints, color='blue', label='BER: {:.2e}'.format(target))
-        plt.fill_between([-10, 0, 10, 0, -10], [0, 30, 0, -30, 0], color='green', label='CDR Mask')
+        plt.fill_between([-10, 0, 10, 0, -10], [0, 30, 0, -30, 0], color='red', label='CDR Mask')
 
         plt.legend()
         plt.show()
@@ -264,6 +264,7 @@ class XpmGth(pr.Device):
         y = 0
 
         for pos in range(-64, 64):
+            print("[{}%] Eye measurement in progress          \r".format(round((float(64.0+pos)/256.0)*100)), end='')
             prev = ber
 
             currY = []
@@ -299,11 +300,11 @@ class XpmGth(pr.Device):
                     positiveY.append(y-2)
                     break
 
-        print("NEGATIVE")
         ber = -1
         y = 0
 
         for pos in range(-64, 64):
+            print("[{}%] Eye measurement in progress          \r".format(round((float(128.0+64.0+pos)/256.0)*100)), end='')
             prev = ber
 
             currY = []
@@ -408,7 +409,7 @@ class XpmGth(pr.Device):
         sampleCount = self.ES_SAMPLE_COUNT.get()
         bitCount = 20*math.pow(2, 1+prescaler)*sampleCount
 
-        print('[{}/{}] Err = {}, Bit = {}'.format(x,y, errCount, bitCount))
+        #print('[{}/{}] Err = {}, Bit = {}'.format(x,y, errCount, bitCount))
 
         if bitCount == 0:
             return 1

--- a/psdaq/psdaq/pyxpm/xpm/_XpmGth.py
+++ b/psdaq/psdaq/pyxpm/xpm/_XpmGth.py
@@ -260,6 +260,8 @@ class XpmGth(pr.Device):
         positiveY = []
         negativeY = []
 
+        print(self.RX_DATA_WIDTH.get())
+
         ber = -1
         y = 0
 
@@ -362,13 +364,16 @@ class XpmGth(pr.Device):
             else:
                 break
 
+        #self.ES_EYE_SCAN_EN.set(0x00)
+        #self.ES_ERRDET_EN.set(0x00)
+
         self.ES_EYE_SCAN_EN.set(0x01)
         self.ES_ERRDET_EN.set(0x01)
 
         self.ES_PRESCALE.set(prescaler)
 
-        self.ES_SDATA_MASK[0].set(0x0000)
-        self.ES_SDATA_MASK[1].set(0x0000)
+        self.ES_SDATA_MASK[0].set(0xffff)
+        self.ES_SDATA_MASK[1].set(0x000f)
         self.ES_SDATA_MASK[2].set(0xff00)
         self.ES_SDATA_MASK[3].set(0xffff)
         self.ES_SDATA_MASK[4].set(0xffff)
@@ -394,22 +399,25 @@ class XpmGth(pr.Device):
         else:
             self.ES_HORZ_OFFSET.set(x)
 
+        #Wait for status being WAIT
         status = self.ES_CONTROL_STATUS.get()
-        while (status & 0x0e) != 0:
+        while (status & 0x01) != 1:
             status = self.ES_CONTROL_STATUS.get()
-            #print("Wait for ready status: {}".format(status))
+            #print('Wait for WAIT status: {}'.format(status))
 
         self.ES_CONTROL.set(0x01)
-        status = self.ES_CONTROL_STATUS.get()
 
-        while not (status & 0x01):
+        #Wait for status being RESET
+        status = self.ES_CONTROL_STATUS.get()
+        while (status & 0x01) != 1:
             status = self.ES_CONTROL_STATUS.get()
+            #print("Wait for ready status: {}".format(status))
 
         errCount = self.ES_ERROR_COUNT.get()
         sampleCount = self.ES_SAMPLE_COUNT.get()
         bitCount = 20*math.pow(2, 1+prescaler)*sampleCount
 
-        #print('[{}/{}] Err = {}, Bit = {}'.format(x,y, errCount, bitCount))
+        print('[{}/{}] Err = {}, Bit = {}           '.format(x,y, errCount, bitCount))
 
         if bitCount == 0:
             return 1

--- a/psdaq/psdaq/pyxpm/xpm/__init__.py
+++ b/psdaq/psdaq/pyxpm/xpm/__init__.py
@@ -13,3 +13,4 @@ from ._GthRxAlignCheck import *
 from ._XpmApp import *
 from ._XpmPhase import *
 from ._XpmSequenceEngine import *
+from ._XpmGth import *


### PR DESCRIPTION
**pyxpm_eyescan.py**: provides functions to get XPM link quality

**Parameters:**

- *--ip* <str>: ip address of the XPM
- *--link <int>*: link identifier from 0 to 13
- *--hseq <int>*: (optional) set HS equalizer value
- *--eye*: generate the eye diagram plot
- *--bathtub*: generate the bathtub plot
- *--target <float>*: set the eye diagram BER (default: 1e-8 - might takes time, recommended 1e-6)
- *--forceLoopback*: force the link to be set in loopback

Usage example: 

```
(ps-4.6.3) [jumdz@drp-neh-ctl002 pyxpm]$ python pyxpm_eyescan.py --ip 10.0.5.104 --link 0 --hseq 191 --eye --target 1e-6

Rogue/pyrogue version v6.1.1. https://github.com/slaclab/rogue
Start: Started zmqServer on ports 9103-9105
    To start a gui: python -m pyrogue gui --server='localhost:9103'
    To use a virtual client: client = pyrogue.interfaces.VirtualClient(addr='localhost', port=9103)
Eyepos generated in 6.694901704788208       
libGL error: unable to load driver: swrast_dri.so
libGL error: failed to load driver: swrast
BER: 3.74e-08 (14 err/ 374224600 rcv)
```

Which generates the following plot:
![image](https://github.com/slac-lcls/lcls2/assets/135361986/9b703049-5724-4d46-8f55-61c7fda057e3)
