### PR TITLE
Delete existing part files on smalldata creation

### DIFF
--- a/psana/psana/smalldata.py
+++ b/psana/psana/smalldata.py
@@ -62,6 +62,7 @@ Some Notes:
 import os
 import numpy as np
 import h5py
+import glob
 from collections.abc import MutableMapping
 
 # -----------------------------------------------------------------------------
@@ -533,6 +534,11 @@ class SmallData: # (client)
         if (filename is not None):
             self._basename = os.path.basename(filename)
             self._dirname  = os.path.dirname(filename)
+
+            # clean up previous part files associated with the filename
+            for f in glob.glob( self._full_filename.replace('.h5','_part*.h5') ):
+                os.remove(f)
+
         self._first_open = True # filename has not been opened yet
 
         if MODE == 'PARALLEL':


### PR DESCRIPTION
When re-running a job with a different number of cores, part files may not not be overwritten. This is the case if the number of SRV nodes of the second job is less than the first one. These additional part files remain on the file system with no purpose and might even create confusion or problems to the unsuspected user.