### PR TITLE
Fix smalldata part file clean up for non str filename and for MPI

### DIFF
--- a/psana/psana/smalldata.py
+++ b/psana/psana/smalldata.py
@@ -471,8 +471,6 @@ class Server: # (hdf5 handling)
                 if cache.n_events > 0:
                     self.write_to_file(dset, cache)
             self.file_handle.close()
-            import time
-            time.sleep(10)
         return
 
 

--- a/psana/psana/smalldata.py
+++ b/psana/psana/smalldata.py
@@ -549,8 +549,6 @@ class SmallData: # (client)
             if self._type != 'other': # other = not smalldata (Mona)
                 self._smalldata_comm.barrier()
 
-
-
         self._first_open = True # filename has not been opened yet
 
         if MODE == 'PARALLEL':

--- a/psana/psana/smalldata.py
+++ b/psana/psana/smalldata.py
@@ -471,7 +471,6 @@ class Server: # (hdf5 handling)
                 if cache.n_events > 0:
                     self.write_to_file(dset, cache)
             self.file_handle.close()
-            time.sleep(10)
         return
 
 

--- a/psana/psana/smalldata.py
+++ b/psana/psana/smalldata.py
@@ -471,6 +471,8 @@ class Server: # (hdf5 handling)
                 if cache.n_events > 0:
                     self.write_to_file(dset, cache)
             self.file_handle.close()
+            import time
+            time.sleep(10)
         return
 
 
@@ -542,6 +544,12 @@ class SmallData: # (client)
                 if self._client_comm.Get_rank() == 0:
                     for f in glob.glob( self._full_filename.replace('.h5','_part*.h5') ):
                         os.remove(f)
+            # Need to make sure all smalldata ranks wait for the clean up to be done
+            # before they go about creating the new files.
+            if self._type != 'other': # other = not smalldata (Mona)
+                self._smalldata_comm.barrier()
+
+
 
         self._first_open = True # filename has not been opened yet
 


### PR DESCRIPTION
This was not as straight-forward as initially thought, especially when running with multiple cores:

- When filename is not passed as  a string (as a Path object for example). I assume that smalldata overall also assumes that self._full_filename  is a string. Luckily this has not been an issue so far for path object. It is now, so I am typecasting filename as str.
- The file clean up must run from a single rank, or conflicts arise when multiple ranks try to delete the same files.
- All other ranks must wait for the clean up to complete, or the new part files are being deleted too.
