### PR TITLE
fix part files removal for serial mode

### DIFF
--- a/psana/psana/smalldata.py
+++ b/psana/psana/smalldata.py
@@ -538,7 +538,6 @@ class SmallData: # (client)
         self._first_open = True # filename has not been opened yet
 
         if MODE == 'PARALLEL':
-
             # hide intermediate files -- join later via VDS
             if filename is not None:
 


### PR DESCRIPTION
Yet another issue that flew under the radar when implementing the removal of part files.
This should allow to run the smalldata test smoothly.
Note that in the current state the test still fails because of ongoing work on implementing the intg_delta_t