### PR TITLE
Enable Timestamp-Based Event Access in RunParallel with `build_table()` Support

### DIFF
--- a/psana/psana/psexp/event_manager.py
+++ b/psana/psana/psexp/event_manager.py
@@ -34,6 +34,7 @@ class EventManager(object):
         view,
         ds,
         run,
+        smd=False,
     ):
         if view:
             pf = PacketFooter(view=view)
@@ -54,6 +55,7 @@ class EventManager(object):
         self.smd_view = view
         self.i_evt = 0
         self.exit_id = ExitId.NoError
+        self.smd_mode = smd
 
         self.logger = utils.get_logger(dsparms=self.ds.dsparms, name=utils.get_class_name(self))
 
@@ -359,6 +361,7 @@ class EventManager(object):
                 self.dm.n_files == 0
                 or not self.isEvent(self.service_array[self.i_evt, i_smd])
                 or self.use_smds[i_smd]
+                or self.smd_mode
             ):
                 view = self.smd_view
                 offset = self.smd_offset_array[self.i_evt, i_smd]

--- a/psana/psana/psexp/mpi_ds.py
+++ b/psana/psana/psexp/mpi_ds.py
@@ -3,6 +3,7 @@ import sys
 import time
 
 import numpy as np
+from contextlib import contextmanager
 
 from psana import dgram
 from psana import utils
@@ -78,11 +79,34 @@ class RunParallel(Run):
         elif nodetype == "eb":
             self.eb_node.start()
         elif nodetype == "bd":
-            for evt in self.bd_node.start():
-                yield evt
+            yield from self.bd_node.start()
         elif nodetype == "srv":
             return
 
+    @contextmanager
+    def build_table(self):
+        success = False
+        if nodetype == "smd0":
+            print("  smd0 start")
+            self.smd0.start()
+        elif nodetype == "eb":
+            self.eb_node.start_broadcast()
+        elif nodetype == "bd":
+            self.bd_node.start_smdonly()
+            success = bool(self._ts_table)
+        yield success
+
+    def event(self, ts):
+        offsets = self._ts_table.get(ts)
+        if offsets is None:
+            raise ValueError(f"Timestamp {ts} not found in offset table.")
+
+        dgrams = [None] * len(self.beginruns)
+        for i, (offset, size) in offsets.items():
+            buf = os.pread(self.ds.dm.fds[i], size, offset)
+            dgrams[i] = dgram.Dgram(config=self.beginruns[i], view=buf)
+
+        return Event(dgrams=dgrams, run=self)
 
 def safe_mpi_abort(msg):
     print(msg)

--- a/psana/psana/psexp/mpi_ds.py
+++ b/psana/psana/psexp/mpi_ds.py
@@ -85,9 +85,17 @@ class RunParallel(Run):
 
     @contextmanager
     def build_table(self):
+        """
+        Context manager for building timestamp-offset table.
+        Returns True only on BigDataNode if the table was successfully built.
+
+        Requires PS_EB_NODES=1 for broadcast mode.
+        """
+        if os.environ.get("PS_EB_NODES", "1") != "1":
+            raise RuntimeError("build_table() currently supports only PS_EB_NODES=1")
+
         success = False
         if nodetype == "smd0":
-            print("  smd0 start")
             self.smd0.start()
         elif nodetype == "eb":
             self.eb_node.start_broadcast()
@@ -101,10 +109,10 @@ class RunParallel(Run):
         if offsets is None:
             raise ValueError(f"Timestamp {ts} not found in offset table.")
 
-        dgrams = [None] * len(self.beginruns)
+        dgrams = [None] * len(self.configs)
         for i, (offset, size) in offsets.items():
             buf = os.pread(self.ds.dm.fds[i], size, offset)
-            dgrams[i] = dgram.Dgram(config=self.beginruns[i], view=buf)
+            dgrams[i] = dgram.Dgram(config=self.ds.dm.configs[i], view=buf)
 
         return Event(dgrams=dgrams, run=self)
 

--- a/psana/psana/psexp/node.py
+++ b/psana/psana/psexp/node.py
@@ -654,15 +654,9 @@ class EventBuilderNode(object):
         wait_for(self.requests)
 
     def start_broadcast(self):
-        rankreq = np.empty(1, dtype="i")
         smd_comm = self.comms.smd_comm
-        n_bd_nodes = self.comms.bd_comm.Get_size() - 1
         bd_comm = self.comms.bd_comm
 
-        # Initialize Non-blocking Send Requests with Null
-        self._init_requests()
-
-        # Broadcast each batch to all BD nodes. Wait for all sends before proceeding.
         while True:
             smd_chunk = self._request_data(smd_comm)
             if not smd_chunk:
@@ -673,21 +667,15 @@ class EventBuilderNode(object):
             )
 
             for smd_batch_dict, _ in eb_man.batches():
-                # assume no destination usage
                 smd_batch, _ = smd_batch_dict[0]
-                for i in range(n_bd_nodes):
-                    self._request_rank(rankreq)
-                    self.requests[rankreq[0] - 1] = bd_comm.Isend(
-                        smd_batch, dest=rankreq[0]
-                    )
-                wait_for(self.requests)
 
-        # - kill all bd nodes
-        self._init_requests()
-        for i in range(n_bd_nodes):
-            self._request_rank(rankreq)
-            self.requests[rankreq[0] - 1] = bd_comm.Isend(bytearray(), dest=rankreq[0])
-        wait_for(self.requests)
+                # Broadcast to all BD ranks including self
+                smd_batch_np = np.frombuffer(smd_batch, dtype='B')
+                bd_comm.bcast(smd_batch_np, root=0)
+
+        # Send empty array to signal termination
+        bd_comm.bcast(np.array([], dtype='B'), root=0)
+
 
 
 class BigDataNode(object):
@@ -746,26 +734,22 @@ class BigDataNode(object):
             yield evt
 
     def start_smdonly(self):
-        def get_smd():
-            bd_comm = self.comms.bd_comm
-            bd_rank = self.comms.bd_rank
-            req = bd_comm.Isend(np.array([bd_rank], dtype="i"), dest=0)
-            req.Wait()
+        bd_comm = self.comms.bd_comm
 
-            info = MPI.Status()
-            bd_comm.Probe(source=0, tag=MPI.ANY_TAG, status=info)
-            count = info.Get_elements(MPI.BYTE)
-            chunk = bytearray(count)
-            req = bd_comm.Irecv(chunk, source=0)
-            req.Wait()
-            return chunk
+        def get_smd():
+            smd_batch_np = bd_comm.bcast(None, root=0)  # receive the broadcast
+            count = smd_batch_np.size
+            return bytearray(smd_batch_np) if count > 0 else bytearray()
 
         t0 = time.monotonic()
 
         events = SmdEvents(self.ds, self.run, get_smd=get_smd)
         self.run._ts_table = {}
 
+        cn_events = 0
+        cn_pass = 0
         for evt in events:
+            cn_events += 1
             if evt.service() != TransitionId.L1Accept:
                 continue
 
@@ -775,5 +759,6 @@ class BigDataNode(object):
                 for i, d in enumerate(evt._dgrams)
                 if d is not None and hasattr(d, 'smdinfo')
             }
+            cn_pass += 1
 
         logger.debug(f"build table took {time.monotonic()-t0:.2f}s.")

--- a/psana/psana/psexp/node.py
+++ b/psana/psana/psexp/node.py
@@ -6,6 +6,7 @@ from psana import utils
 from psana.dgram import Dgram
 from psana.psexp.eventbuilder_manager import EventBuilderManager
 from psana.psexp.events import Events
+from psana.psexp.smd_events import SmdEvents
 from psana.psexp.packet_footer import PacketFooter
 from psana.psexp.tools import mode
 
@@ -651,6 +652,44 @@ class EventBuilderNode(object):
             self.logger.debug(f"MESSAGE EB-BD ({self.comms.smd_rank}-{dest_rank}) KILL")
         wait_for(self.requests)
 
+    def start_broadcast(self):
+        print("[DEBUG-EB] start_broadcast called")
+        rankreq = np.empty(1, dtype="i")
+        smd_comm = self.comms.smd_comm
+        n_bd_nodes = self.comms.bd_comm.Get_size() - 1
+        bd_comm = self.comms.bd_comm
+
+        # Initialize Non-blocking Send Requests with Null
+        self._init_requests()
+
+        # Broadcast each batch to all BD nodes. Wait for all sends before proceeding.
+        while True:
+            smd_chunk = self._request_data(smd_comm)
+            if not smd_chunk:
+                break
+
+            eb_man = EventBuilderManager(
+                smd_chunk, self.configs, self.dsparms, self.dm.get_run()
+            )
+
+            for smd_batch_dict, _ in eb_man.batches():
+                print("[DEBUG-EB] received smd_batch_dict")
+                # assume no destination usage
+                smd_batch, _ = smd_batch_dict[0]
+                for i in range(n_bd_nodes):
+                    self._request_rank(rankreq)
+                    self.requests[rankreq[0] - 1] = bd_comm.Isend(
+                        smd_batch, dest=rankreq[0]
+                    )
+                wait_for(self.requests)
+
+        # - kill all bd nodes
+        self._init_requests()
+        for i in range(n_bd_nodes):
+            self._request_rank(rankreq)
+            self.requests[rankreq[0] - 1] = bd_comm.Isend(bytearray(), dest=rankreq[0])
+        wait_for(self.requests)
+
 
 class BigDataNode(object):
     def __init__(self, ds, run):
@@ -706,3 +745,30 @@ class BigDataNode(object):
                     t0 = time.monotonic()
 
             yield evt
+
+    def start_smdonly(self):
+        def get_smd():
+            bd_comm = self.comms.bd_comm
+            bd_rank = self.comms.bd_rank
+            req = bd_comm.Isend(np.array([bd_rank], dtype="i"), dest=0)
+            req.Wait()
+
+            info = MPI.Status()
+            bd_comm.Probe(source=0, tag=MPI.ANY_TAG, status=info)
+            count = info.Get_elements(MPI.BYTE)
+            chunk = bytearray(count)
+            req = bd_comm.Irecv(chunk, source=0)
+            req.Wait()
+            return chunk
+
+        events = SmdEvents(self.ds, self.run, get_smd=get_smd)
+        self.run._ts_table = {}
+
+        for evt in events:
+            ts = evt.timestamp
+            self.run._ts_table[ts] = {
+                i: (d.smdinfo[0].offsetAlg.intOffset, d._size)
+                for i, d in enumerate(evt._dgrams)
+                if d is not None and hasattr(d, 'smdinfo')
+            }
+            print(ts, self.run._ts_table[ts])

--- a/psana/psana/psexp/node.py
+++ b/psana/psana/psexp/node.py
@@ -761,4 +761,4 @@ class BigDataNode(object):
             }
             cn_pass += 1
 
-        logger.debug(f"build table took {time.monotonic()-t0:.2f}s.")
+        self.logger.debug(f"build table took {time.monotonic()-t0:.2f}s.")

--- a/psana/psana/psexp/smd_events.py
+++ b/psana/psana/psexp/smd_events.py
@@ -1,0 +1,30 @@
+from .event_manager import EventManager
+
+class SmdEvents:
+    def __init__(self, ds, run, get_smd):
+        self.ds = ds
+        self.run = run
+        self.get_smd = get_smd
+        self._evt_man = iter([])
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        try:
+            evt = next(self._evt_man)
+            if not any(evt._dgrams):
+                return self.__next__()
+            return evt
+        except StopIteration:
+            smd_batch = self.get_smd()
+            if smd_batch == bytearray():
+                raise StopIteration
+
+            self._evt_man = EventManager(
+                smd_batch,
+                self.ds,
+                self.run,
+                smd=True,
+            )
+            return self.__next__()

--- a/psana/psana/tests/setup_input_files.py
+++ b/psana/psana/tests/setup_input_files.py
@@ -1,5 +1,4 @@
 import subprocess
-import shutil
 
 def setup_input_files(tmp_path, n_files=2, slow_update_freq=4, n_motor_steps=1, n_events_per_step=10, gen_run2=True):
     xtc_dir = tmp_path / '.tmp'
@@ -16,6 +15,8 @@ def setup_input_files(tmp_path, n_files=2, slow_update_freq=4, n_motor_steps=1, 
         sfile = str(xtc_dir / filename)
         subprocess.call(['xtcwriter','-f',sfile,'-t','-n',str(n_events_per_step),'-s',str(i*2),'-e',str(slow_update_freq),'-m',str(n_motor_steps)])
         subprocess.call(['smdwriter','-f',sfile,'-o',str(smd_dir / smd_filename)])
+
+    return xtc_dir
 
 if __name__ == "__main__":
     import pathlib

--- a/psana/psana/tests/test_build_table_performance.py
+++ b/psana/psana/tests/test_build_table_performance.py
@@ -1,0 +1,166 @@
+"""
+test_build_table_performance.py
+
+MPI-based pytest for testing timestamp-based access and standard event iteration using
+prefetched Jungfrau calibration data in a distributed setup.
+
+PREREQUISITES BEFORE RUNNING:
+--------------------------------
+1. Allocate 3 exclusive nodes for MPI jobs:
+    salloc -N3 --exclusive --account=lcls:data -p milano
+   Add the 3 nodes in slurm_host_test with this format:
+   node0 slots=2
+   node1 slots=120
+   node2 slots=120
+
+2. Create softlinks for *only* run 45 to avoid loading all runs:
+   For smalldata:
+       for i in $(seq 0 9); do
+           ln -s /sdf/data/lcls/ds/mfx/mfx100852324/xtc/smalldata/mfx100852324-r0045-s00$i-c000.smd.xtc2 \
+                 mfx100852324-r0045-s00$i-c000.smd.xtc2
+       done
+
+   For bigdata:
+       for i in $(seq 0 9); do
+           ln -s /sdf/data/lcls/ds/mfx/mfx100852324/xtc/bigdata/mfx100852324-r0045-s00$i-c000.xtc2 \
+                 mfx100852324-r0045-s00$i-c000.xtc2
+       done
+
+3. Prefetch Jungfrau calibration data on a shared filesystem:
+    calib_prefetch --xtc-dir /sdf/home/m/monarin/tmp/lcls2/psana/psana/tests/tmp_xtc \
+                   -e mfx100852324 --log-level DEBUG --detectors jungfrau
+
+4. Copy calibration files to each allocated node:
+    scp /dev/shm/*.pkl sdfmilan048:/dev/shm
+    # Repeat for each node in your salloc allocation (e.g., sdfmilan049, sdfmilan050, etc.)
+
+USAGE:
+-------
+- Pytest (with markers and MPI):
+    mpirun -n 242 --hostfile=slurm_host_test pytest -m slow test_build_table_performance.py
+
+- Standalone:
+    mpirun -n 242 --hostfile=slurm_host_test python test_build_table_performance.py
+"""
+
+import os
+import numpy as np
+from psana import DataSource
+from mpi4py import MPI
+import pytest
+
+comm = MPI.COMM_WORLD
+size = comm.Get_size()
+rank = comm.Get_rank()
+group = comm.Get_group()
+n_bd_ranks = size - int(os.environ.get('PS_EB_NODES', '1')) - 1
+xtc_dir = "/sdf/data/lcls/ds/mfx/mfx100852324/xtc"
+
+pytestmark = pytest.mark.slow
+
+skip_if_missing_xtc = pytest.mark.skipif(
+    not os.path.exists(xtc_dir),
+    reason=f"XTC directory {xtc_dir} not found."
+)
+
+@skip_if_missing_xtc
+def test_normal_ds():
+    ds = DataSource(exp='mfx100852324', run=45, dir=xtc_dir, max_events=0,
+                    use_calib_cache=True, cached_detectors=["jungfrau"],
+                    log_level='INFO', batch_size=100)
+    run = next(ds.runs())
+    det = run.Detector('jungfrau')
+
+    n_counters = 1
+    sendbuf = np.zeros(n_counters, dtype="i")
+    recvbuf = np.empty([size, n_counters], dtype="i") if rank == 0 else None
+
+    comm.Barrier()
+    t0 = MPI.Wtime()
+    for i_evt, evt in enumerate(run.events()):
+        img = det.raw.raw(evt)
+        assert img is not None
+        sendbuf[:] = [i_evt + 1]
+
+    comm.Gather(sendbuf, recvbuf, root=0)
+    comm.Barrier()
+    if rank == 0:
+        sum_events = np.sum(recvbuf, axis=0)[0]
+        total_time = MPI.Wtime() - t0
+        print(f"[test_normal_ds] Total time: {total_time:.2f}s. Events: {sum_events} Rate: {(sum_events / total_time) * 1e-3:.2f}kHz")
+
+
+@skip_if_missing_xtc
+def test_ts_access_ds():
+    ds = DataSource(exp='mfx100852324', run=45, dir=xtc_dir, max_events=0,
+                    use_calib_cache=True, cached_detectors=["jungfrau"],
+                    log_level='INFO')
+    run = next(ds.runs())
+    det = run.Detector('jungfrau')
+
+    comm.Barrier()
+    t0 = MPI.Wtime()
+
+    bd_group = group.Excl([0, 1])
+    bd_comm = comm.Create(bd_group)
+    sum_events = 0
+
+    with run.build_table() as success:
+        if success:
+            bd_offset = int(os.environ.get('PS_EB_NODES', '1')) + 1
+            bd_rank = rank - bd_offset
+
+            if bd_rank >= 0:
+                bd_comm_rank = bd_comm.Get_rank()
+                bd_comm_size = bd_comm.Get_size()
+                t_read_start = MPI.Wtime()
+                cn_events = 0
+
+                sendbuf = np.zeros(1, dtype="i")
+                recvbuf = np.empty([bd_comm_size, 1], dtype="i") if bd_comm_rank == 0 else None
+
+                if bd_comm_rank == 0:
+                    valid_ts = sorted(k for k in run._ts_table if run._ts_table[k])
+                    print(f'build_table took {MPI.Wtime() - t0:.2f}s. {len(valid_ts)=}')
+                    for ts in valid_ts:
+                        recv_rank = bd_comm.recv(source=MPI.ANY_SOURCE)
+                        bd_comm.send(ts, dest=recv_rank)
+
+                    for _ in range(1, bd_comm_size):
+                        recv_rank = bd_comm.recv(source=MPI.ANY_SOURCE)
+                        bd_comm.send(None, dest=recv_rank)
+
+                else:
+                    while True:
+                        bd_comm.send(bd_comm_rank, dest=0)
+                        ts = bd_comm.recv(source=0)
+                        if ts is None:
+                            break
+                        evt = run.event(ts)
+                        assert evt is not None and len(evt._dgrams) > 0
+                        img = det.raw.raw(evt)
+                        assert img is not None
+                        cn_events += 1
+
+                    sendbuf[:] = [cn_events]
+
+                t_read_end = MPI.Wtime()
+                print(f"[Rank {rank}] Processed {cn_events} events in {t_read_end - t_read_start:.2f}s. "
+                      f"Rate={(cn_events / (t_read_end - t_read_start)) * 1e-3:.4f}kHz")
+
+                bd_comm.Gather(sendbuf, recvbuf, root=0)
+                if bd_comm_rank == 0:
+                    sum_events = np.sum(recvbuf, axis=0)[0]
+                    total_time = MPI.Wtime() - t0
+                    print(f"[test_ts_access_ds] Total time: {total_time:.2f}s. Events: {sum_events} Rate: {(sum_events / total_time) * 1e-3:.2f}kHz")
+
+
+if __name__ == "__main__":
+    if os.path.exists(xtc_dir):
+        if rank == 0:
+            print("Running tests directly (slow tests)")
+        test_normal_ds()
+        test_ts_access_ds()
+    else:
+        if rank == 0:
+            print(f"XTC directory {xtc_dir} not found. Skipping tests.")

--- a/psana/psana/tests/test_runparallel_build_table.py
+++ b/psana/psana/tests/test_runparallel_build_table.py
@@ -1,0 +1,56 @@
+import pytest
+
+# Only import MPI if available
+try:
+    from mpi4py import MPI
+    mpi_available = True
+except ImportError:
+    mpi_available = False
+
+from psana import DataSource
+from setup_input_files import setup_input_files
+
+@pytest.mark.skipif(not mpi_available or MPI.COMM_WORLD.Get_size() < 3,
+                    reason="Requires MPI with at least 3 ranks")
+def test_runparallel_build_table(tmp_path):
+    """
+    Test for building the timestamp-to-offset table in RunParallel with MPI.
+    This ensures that psana2 can selectively fetch events by timestamp.
+
+    Requires running with at least 3 MPI ranks (smd0, eb, and at least one bd).
+    """
+    xtc_dir = setup_input_files(tmp_path)
+
+    ds = DataSource(exp='xpptut15', run=14, dir=str(xtc_dir))
+    run = next(ds.runs())
+
+    # Only BigDataNode ranks will populate _ts_table
+    with run.build_table() as success:
+        if success:
+            # Ensure that _ts_table is populated with some valid timestamps
+            assert hasattr(run, '_ts_table')
+            assert isinstance(run._ts_table, dict)
+            assert len(run._ts_table) > 0
+
+            # Optionally verify a few entries have non-empty offsets
+            non_empty_entries = [ts for ts, v in run._ts_table.items() if v]
+            assert len(non_empty_entries) > 0
+
+            # Sample the first few entries to verify we can access the events
+            #for i, ts in enumerate(sorted(non_empty_entries[:5])):
+            #    evt = run.event(ts)
+            #    assert evt is not None
+            #assert len(evt._dgrams) > 0
+
+
+if __name__ == "__main__":
+    import tempfile
+    from pathlib import Path
+
+    if not mpi_available or MPI.COMM_WORLD.Get_size() < 3:
+        print("This script requires MPI with at least 3 ranks.")
+        exit(0)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        test_runparallel_build_table(tmp_path)

--- a/psana/psana/tests/test_runparallel_build_table.py
+++ b/psana/psana/tests/test_runparallel_build_table.py
@@ -1,4 +1,7 @@
 import pytest
+import random
+import vals
+import numpy as np
 
 # Only import MPI if available
 try:
@@ -19,7 +22,7 @@ def test_runparallel_build_table(tmp_path):
 
     Requires running with at least 3 MPI ranks (smd0, eb, and at least one bd).
     """
-    xtc_dir = setup_input_files(tmp_path)
+    xtc_dir = prepare_xtc_dir(tmp_path)
 
     ds = DataSource(exp='xpptut15', run=14, dir=str(xtc_dir))
     run = next(ds.runs())
@@ -27,21 +30,36 @@ def test_runparallel_build_table(tmp_path):
     # Only BigDataNode ranks will populate _ts_table
     with run.build_table() as success:
         if success:
-            # Ensure that _ts_table is populated with some valid timestamps
-            assert hasattr(run, '_ts_table')
-            assert isinstance(run._ts_table, dict)
-            assert len(run._ts_table) > 0
+            # Extract first 10 valid timestamps (those with non-empty offset info)
+            valid_ts = sorted(k for k in run._ts_table if run._ts_table[k])[:10]
+            assert len(valid_ts) == 10, "Expected at least 10 L1Accept events with offsets"
 
-            # Optionally verify a few entries have non-empty offsets
-            non_empty_entries = [ts for ts, v in run._ts_table.items() if v]
-            assert len(non_empty_entries) > 0
+            # Randomly pick 3 timestamps to test
+            sample_ts = random.sample(valid_ts, 3)
+            for ts in sample_ts:
+                evt = run.event(ts)
+                assert evt is not None
+                assert len(evt._dgrams) > 0
 
-            # Sample the first few entries to verify we can access the events
-            #for i, ts in enumerate(sorted(non_empty_entries[:5])):
-            #    evt = run.event(ts)
-            #    assert evt is not None
-            #assert len(evt._dgrams) > 0
+                det = run.Detector('xppcspad')
+                padarray = vals.padarray
+                assert(np.array_equal(det.raw.calib(evt),np.stack((padarray,padarray,padarray,padarray))))
 
+
+def prepare_xtc_dir(tmp_path):
+    comm = MPI.COMM_WORLD if mpi_available else None
+    rank = comm.Get_rank() if comm else 0
+
+    if rank == 0:
+        xtc_dir = setup_input_files(tmp_path)
+    else:
+        xtc_dir = tmp_path  # Other ranks will use the same path without setup
+
+    # Barrier to ensure rank 0 completes setup before others proceed
+    if comm:
+        comm.Barrier()
+
+    return xtc_dir
 
 if __name__ == "__main__":
     import tempfile

--- a/psana/psana/utils.py
+++ b/psana/psana/utils.py
@@ -1,8 +1,41 @@
 import inspect
 import logging
-import os
 from pathlib import Path
 from logging.handlers import RotatingFileHandler
+from psana.psexp.tools import mode
+
+def get_class_name(obj):
+    """
+    Returns the class name of the given object instance.
+    """
+    try:
+        return obj.__class__.__name__
+    except AttributeError:
+        return str(type(obj))  # fallback for non-class cases
+
+
+def get_logger(dsparms=None, name=None, timestamp=False):
+    if mode == "mpi":
+        from mpi4py import MPI
+        rank = MPI.COMM_WORLD.Get_rank()
+    else:
+        rank = 0
+
+    level = getattr(dsparms, "log_level", "INFO")
+    logfile = getattr(dsparms, "log_file", None)
+
+    # Add .rankX suffix if logfile is defined and running in MPI
+    if logfile and rank is not None:
+        path = Path(logfile)
+        logfile = str(path.with_name(f"{path.stem}.rank{rank}{path.suffix}"))
+
+    return Logger(
+        name=name,
+        level=level,
+        myrank=rank,
+        logfile=logfile,
+        timestamp=timestamp
+    )
 from psana.psexp.tools import mode
 
 def get_class_name(obj):

--- a/psana/psana/utils.py
+++ b/psana/psana/utils.py
@@ -1,41 +1,8 @@
 import inspect
 import logging
+import os
 from pathlib import Path
 from logging.handlers import RotatingFileHandler
-from psana.psexp.tools import mode
-
-def get_class_name(obj):
-    """
-    Returns the class name of the given object instance.
-    """
-    try:
-        return obj.__class__.__name__
-    except AttributeError:
-        return str(type(obj))  # fallback for non-class cases
-
-
-def get_logger(dsparms=None, name=None, timestamp=False):
-    if mode == "mpi":
-        from mpi4py import MPI
-        rank = MPI.COMM_WORLD.Get_rank()
-    else:
-        rank = 0
-
-    level = getattr(dsparms, "log_level", "INFO")
-    logfile = getattr(dsparms, "log_file", None)
-
-    # Add .rankX suffix if logfile is defined and running in MPI
-    if logfile and rank is not None:
-        path = Path(logfile)
-        logfile = str(path.with_name(f"{path.stem}.rank{rank}{path.suffix}"))
-
-    return Logger(
-        name=name,
-        level=level,
-        myrank=rank,
-        logfile=logfile,
-        timestamp=timestamp
-    )
 from psana.psexp.tools import mode
 
 def get_class_name(obj):


### PR DESCRIPTION
# Description
This PR introduces a new `run.build_table()` interface to support timestamp-based event access in `RunParallel`. The key feature is the ability to retrieve events by specific timestamps using:

```python
with run.build_table() as success:
    if success:
        evt = run.event(ts)
```

## Highlights:
- ✅ `build_table()` generates a timestamp-to-offset map during data loading using BigData ranks only.
- ✅ Context-managed API ensures `_ts_table` is ready before proceeding.
- ✅ New examples added:
  - [Unit test with timestamp access](https://github.com/slac-lcls/lcls2/blob/features/timestamp_event_access/psana/psana/tests/test_runparallel_build_table.py)
  - [Performance benchmark with client-server BD workers](https://github.com/slac-lcls/lcls2/blob/features/timestamp_event_access/psana/psana/tests/run_build_table_performance.py)
- ✅ `run.event(ts)` now supported in both single-process and MPI-parallel modes.
- ✅ Performance tuned with `det.raw.raw(evt)` yielding up to **11.1 GB/s throughput** across 240 BD workers on 2 nodes (40,000 events in ~126s).
- ✅ EventBuilder `start_broadcast()` now uses MPI `bcast` to ensure all BD ranks receive identical data batches.
- ✅ Fixes synchronization bugs where different BD ranks previously received different numbers of timestamps.

## Notes:
- Currently supports **only one EventBuilder** rank.
- HDF5/SmD writer (Srv) ranks are excluded unless data is explicitly forwarded.
- `build_table()` is blocking by design and ensures consistency before usage.

This PR also integrates the latest `master` to remain up-to-date.