### PR TITLE
Fix class name collisions in VarDef subclasses

### DIFF
--- a/psdaq/drp/AreaDetector.cc
+++ b/psdaq/drp/AreaDetector.cc
@@ -14,37 +14,39 @@ using logging = psalg::SysLog;
 
 namespace Drp {
 
-class FexDef : public VarDef
-{
-public:
-    enum index
-    {
-        array_fex
-    };
+    namespace {
+        class FexDef : public VarDef
+        {
+        public:
+            enum index
+                {
+                    array_fex
+                };
+        
+            FexDef()
+            {
+                Alg fex("fex", 1, 0, 0);
+                NameVec.push_back({"array_fex", Name::UINT16, 2, fex});
+            }
+        } _fexDef;
 
-    FexDef()
-    {
-        Alg fex("fex", 1, 0, 0);
-        NameVec.push_back({"array_fex", Name::UINT16, 2, fex});
+        class RawDef : public VarDef
+        {
+        public:
+            enum index
+                {
+                    value,
+                    array_raw
+                };
+        
+            RawDef()
+            {
+                Alg raw("raw", 1, 0, 0);
+                NameVec.push_back({"value",     Name::UINT32, 0, raw});
+                NameVec.push_back({"array_raw", Name::UINT16, 2, raw});
+            }
+        } _rawDef;
     }
-} _fexDef;
-
-class RawDef : public VarDef
-{
-public:
-    enum index
-    {
-        value,
-        array_raw
-    };
-
-    RawDef()
-    {
-        Alg raw("raw", 1, 0, 0);
-        NameVec.push_back({"value",     Name::UINT32, 0, raw});
-        NameVec.push_back({"array_raw", Name::UINT16, 2, raw});
-    }
-} _rawDef;
 
 AreaDetector::AreaDetector(Parameters* para, MemPool* pool) :
     XpmDetector(para, pool),

--- a/psdaq/drp/EpixHRemu.cc
+++ b/psdaq/drp/EpixHRemu.cc
@@ -18,126 +18,127 @@ using logging = psalg::SysLog;
 
 namespace Drp {
 
-class RawDef : public VarDef
-{
-public:
-    enum index
-    {
-        raw
+    namespace {
+        class RawDef : public VarDef
+        {
+        public:
+            enum index
+                {
+                    raw
+                };
+
+            RawDef()
+            {
+                Alg raw("raw", 2, 0, 0);
+                NameVec.push_back({"raw", Name::UINT16, 2, raw});
+            }
+        };
+
+        class XtcCopyIter : public XtcIterator
+        {
+        public:
+            enum { Stop, Continue };
+            XtcCopyIter(unsigned numWords, void*& buffer) :
+                XtcIterator(),
+                _numWords(numWords),
+                _buffer(buffer)
+            {
+            }
+
+            bool get_value(int i, Name& name, DescData& descdata)
+            {
+                int data_rank = name.rank();
+                int data_type = name.type();
+                logging::debug("%d: '%s' rank %d, type %d\n", i, name.name(), data_rank, data_type);
+
+                std::string dscName(name.name());
+                if ((dscName != "raw") || (data_type != Name::UINT16) || (data_rank != 2)) {
+                    return false;
+                }
+
+                unsigned maxWords = 1;
+                char buffer[128];
+                int n = 0;
+                n += snprintf(&buffer[n], sizeof(buffer) - n, "'%s' ", name.name());
+                n += snprintf(&buffer[n], sizeof(buffer) - n, "(shape:");
+                auto shape = descdata.shape(name);
+                for (unsigned w = 0; w < name.rank(); w++) {
+                    n += snprintf(&buffer[n], sizeof(buffer) - n, " %d",shape[w]);
+                    maxWords *= shape[w];
+                }
+                n += snprintf(&buffer[n], sizeof(buffer) - n, "):");
+                unsigned numWords = _numWords;
+                if (maxWords < numWords)
+                    numWords = maxWords;
+
+                if (_buffer) {
+                    for (unsigned w = 0; w < 5; ++w) {
+                        n += snprintf(&buffer[n], sizeof(buffer) - n, " %04x", descdata.get_array<uint16_t>(i).data()[w]);
+                    }
+                    n += snprintf(&buffer[n], sizeof(buffer) - n, "\n");
+                    logging::debug("%s", buffer);
+                    memcpy(_buffer, descdata.get_array<uint16_t>(i).data(), numWords * sizeof(uint16_t));
+                }
+
+                return true;
+            }
+
+            int process(Xtc* xtc, const void* bufEnd)
+            {
+                switch (xtc->contains.id()) {
+                case (TypeId::Parent): {
+                    iterate(xtc, bufEnd);
+                    break;
+                }
+                case (TypeId::Names): {
+                    Names& names = *(Names*)xtc;
+                    _namesLookup[names.namesId()] = NameIndex(names);
+                    Alg& alg = names.alg();
+                    logging::debug("DetName: %s, Segment %d, DetType: %s, DetId: %s, Alg: %s, Version: 0x%6.6x, namesid: 0x%x, Names:\n",
+                                   names.detName(), names.segment(), names.detType(), names.detId(),
+                                   alg.name(), alg.version(), (int)names.namesId());
+
+                    for (unsigned i = 0; i < names.num(); i++) {
+                        Name& name = names.get(i);
+                        logging::debug("Name: '%s' Type: %d Rank: %d\n",name.name(),name.type(), name.rank());
+                    }
+
+                    break;
+                }
+                case (TypeId::ShapesData): {
+                    ShapesData& shapesdata = *(ShapesData*)xtc;
+                    // lookup the index of the names we are supposed to use
+                    NamesId namesId = shapesdata.namesId();
+                    // protect against the fact that this namesid
+                    // may not have a NamesLookup.  cpo thinks this
+                    // should be fatal, since it is a sign the xtc is "corrupted",
+                    // in some sense.
+                    if (_namesLookup.count(namesId)<=0) {
+                        logging::critical("Corrupt xtc: namesid 0x%x not found in NamesLookup\n",(unsigned)namesId);
+                        throw "invalid namesid";
+                        break;
+                    }
+                    DescData descdata(shapesdata, _namesLookup[namesId]);
+                    Names& names = descdata.nameindex().names();
+                    logging::debug("Found %d names for namesid 0x%x\n",names.num(),(unsigned)namesId);
+                    for (unsigned i = 0; i < names.num(); i++) {
+                        Name& name = names.get(i);
+                        if (get_value(i, name, descdata))  break;
+                    }
+                    break;
+                }
+                default:
+                    break;
+                }
+                return Continue;
+            }
+
+        private:
+            NamesLookup _namesLookup;
+            unsigned _numWords;
+            void*& _buffer;
+        };
     };
-
-    RawDef()
-    {
-        Alg raw("raw", 2, 0, 0);
-        NameVec.push_back({"raw", Name::UINT16, 2, raw});
-    }
-};
-
-class XtcCopyIter : public XtcIterator
-{
-public:
-    enum { Stop, Continue };
-    XtcCopyIter(unsigned numWords, void*& buffer) :
-        XtcIterator(),
-        _numWords(numWords),
-        _buffer(buffer)
-    {
-    }
-
-    bool get_value(int i, Name& name, DescData& descdata)
-    {
-        int data_rank = name.rank();
-        int data_type = name.type();
-        logging::debug("%d: '%s' rank %d, type %d\n", i, name.name(), data_rank, data_type);
-
-        std::string dscName(name.name());
-        if ((dscName != "raw") || (data_type != Name::UINT16) || (data_rank != 2)) {
-            return false;
-        }
-
-        unsigned maxWords = 1;
-        char buffer[128];
-        int n = 0;
-        n += snprintf(&buffer[n], sizeof(buffer) - n, "'%s' ", name.name());
-        n += snprintf(&buffer[n], sizeof(buffer) - n, "(shape:");
-        auto shape = descdata.shape(name);
-        for (unsigned w = 0; w < name.rank(); w++) {
-            n += snprintf(&buffer[n], sizeof(buffer) - n, " %d",shape[w]);
-            maxWords *= shape[w];
-        }
-        n += snprintf(&buffer[n], sizeof(buffer) - n, "):");
-        unsigned numWords = _numWords;
-        if (maxWords < numWords)
-            numWords = maxWords;
-
-        if (_buffer) {
-            for (unsigned w = 0; w < 5; ++w) {
-                n += snprintf(&buffer[n], sizeof(buffer) - n, " %04x", descdata.get_array<uint16_t>(i).data()[w]);
-            }
-            n += snprintf(&buffer[n], sizeof(buffer) - n, "\n");
-            logging::debug("%s", buffer);
-            memcpy(_buffer, descdata.get_array<uint16_t>(i).data(), numWords * sizeof(uint16_t));
-        }
-
-        return true;
-    }
-
-    int process(Xtc* xtc, const void* bufEnd)
-    {
-        switch (xtc->contains.id()) {
-        case (TypeId::Parent): {
-            iterate(xtc, bufEnd);
-            break;
-        }
-        case (TypeId::Names): {
-            Names& names = *(Names*)xtc;
-            _namesLookup[names.namesId()] = NameIndex(names);
-            Alg& alg = names.alg();
-            logging::debug("DetName: %s, Segment %d, DetType: %s, DetId: %s, Alg: %s, Version: 0x%6.6x, namesid: 0x%x, Names:\n",
-                           names.detName(), names.segment(), names.detType(), names.detId(),
-                           alg.name(), alg.version(), (int)names.namesId());
-
-            for (unsigned i = 0; i < names.num(); i++) {
-                Name& name = names.get(i);
-                logging::debug("Name: '%s' Type: %d Rank: %d\n",name.name(),name.type(), name.rank());
-            }
-
-            break;
-        }
-        case (TypeId::ShapesData): {
-            ShapesData& shapesdata = *(ShapesData*)xtc;
-            // lookup the index of the names we are supposed to use
-            NamesId namesId = shapesdata.namesId();
-            // protect against the fact that this namesid
-            // may not have a NamesLookup.  cpo thinks this
-            // should be fatal, since it is a sign the xtc is "corrupted",
-            // in some sense.
-            if (_namesLookup.count(namesId)<=0) {
-                logging::critical("Corrupt xtc: namesid 0x%x not found in NamesLookup\n",(unsigned)namesId);
-                throw "invalid namesid";
-                break;
-            }
-            DescData descdata(shapesdata, _namesLookup[namesId]);
-            Names& names = descdata.nameindex().names();
-            logging::debug("Found %d names for namesid 0x%x\n",names.num(),(unsigned)namesId);
-            for (unsigned i = 0; i < names.num(); i++) {
-                Name& name = names.get(i);
-                if (get_value(i, name, descdata))  break;
-            }
-            break;
-        }
-        default:
-            break;
-        }
-        return Continue;
-    }
-
-private:
-    NamesLookup _namesLookup;
-    unsigned _numWords;
-    void*& _buffer;
-};
-
 
 EpixHRemu::EpixHRemu(Parameters* para, MemPool* pool) :
     XpmDetector(para, pool)

--- a/psdaq/drp/Opal.cc
+++ b/psdaq/drp/Opal.cc
@@ -21,19 +21,19 @@
 #include <algorithm>
 
 using namespace XtcData;
+using namespace Drp;
 using logging = psalg::SysLog;
 using json = nlohmann::json;
 
 //#define DBUG
 
-namespace Drp {
-
+namespace {
     class RawDef : public VarDef
     {
     public:
         enum index { image };
         RawDef() { NameVec.push_back({"image", Name::UINT16, 2}); }
-    } rawDef;
+    };
 
     class FexDef : public VarDef
     {
@@ -90,7 +90,9 @@ namespace Drp {
             }
         }
     };
+};
 
+namespace Drp {
     class OpalTT {
     public:
         OpalTT(Opal& d, Parameters* para);
@@ -143,11 +145,11 @@ namespace Drp {
         unsigned              m_evtindex;
     };
 
-    class L2Iter : public XtcIterator
+    class OpalTTL2Iter : public XtcIterator
     {
     public:
         enum { Stop, Continue };
-        L2Iter() : XtcIterator() {}
+        OpalTTL2Iter() : XtcIterator() {}
 
         void get_value(int i, Name& name, DescData& descdata);
         int process(Xtc*, const void* bufEnd);
@@ -172,11 +174,10 @@ namespace Drp {
         Pds::Semaphore        m_filesem;
         XtcFileIterator*      m_iter;
         XtcFileIterator*      m_timiter;
-        L2Iter                m_input;
-        L2Iter                m_timinput;
+        OpalTTL2Iter          m_input;
+        OpalTTL2Iter          m_timinput;
     };
-
-};
+}
 
 //
 //  Data types from LCLS-1
@@ -230,12 +231,6 @@ namespace PdsL1 {
 
 static void _load_xtc(std::vector<uint8_t>&, const char*);
 
-
-using Drp::Opal;
-using Drp::OpalTT;
-using Drp::OpalTTFex;
-using Drp::OpalTTSimL1;
-using Drp::OpalTTSimL2;
 
 Opal::Opal(Parameters* para, MemPool* pool) :
     BEBDetector   (para, pool),
@@ -305,7 +300,8 @@ unsigned Opal::_configure(XtcData::Xtc& xtc,const void* bufEnd,XtcData::ConfigIt
                                                m_para->detName.c_str(), alg,
                                                m_para->detType.c_str(), m_para->serNo.c_str(), m_evtNamesId, m_para->detSegment);
 
-    eventNames.add(xtc, bufEnd, Drp::rawDef);
+    RawDef rawDef;
+    eventNames.add(xtc, bufEnd, rawDef);
     m_namesLookup[m_evtNamesId] = NameIndex(eventNames);
 
     if (m_tt) { delete m_tt; m_tt = 0; }
@@ -336,6 +332,7 @@ void Opal::write_image(XtcData::Xtc& xtc, const void* bufEnd, std::vector< XtcDa
     unsigned shape[MaxRank];
     shape[0] = m_rows;
     shape[1] = m_columns;
+    
     Array<uint16_t> arrayT = cd.allocate<uint16_t>(RawDef::image, shape);
     memcpy(arrayT.data(), subframes[2].data(), subframes[2].shape()[0]);
 }
@@ -790,7 +787,7 @@ void _load_xtc(std::vector<uint8_t>& buffer, const char* filename)
     }
 }
 
-int Drp::L2Iter::process(Xtc* xtc, const void* bufEnd)
+int Drp::OpalTTL2Iter::process(Xtc* xtc, const void* bufEnd)
 {
     switch (xtc->contains.id()) {
     case (TypeId::Parent): {

--- a/psdaq/drp/Piranha4.cc
+++ b/psdaq/drp/Piranha4.cc
@@ -183,62 +183,62 @@ namespace Drp {
             L2Iter                m_timinput;
         };
     };
-};
 
-//
-//  Data types from LCLS-1
-//
-namespace PdsL1 {
-    class Xtc {
-    public:
-        char* payload() { return (char*)(this+1); }
-        uint32_t damage;
-        uint32_t src_log;
-        uint32_t src_phy;
-        uint32_t contains;
-        uint32_t extent;
-    };
-    class FrameV1 {
-    public:
-        uint16_t*   data() { return reinterpret_cast<uint16_t*>(this+1); }
-        uint16_t&   operator()(unsigned pix) { return data()[pix]; }
-        uint32_t	_pixels;	/**< Number of pixels. */
-        uint32_t	_depth;	/**< Number of bits per pixel. */
-        uint32_t	_offset;	/**< Fixed offset/pedestal value of pixel data. */
-        //uint8_t	_pixel_data[this->_pixels*((this->_depth+7)/8)];
-    };
-    class FIFOEvent {
-    public:
-        uint32_t	_timestampHigh;	/**< 119 MHz timestamp (fiducial) */
-        uint32_t	_timestampLow;	/**< 360 Hz timestamp */
-        uint32_t	_eventCode;	/**< event code (range 0-255) */
-    };
-    class EvrDataV4 {
-    public:
-        uint32_t	_u32NumFifoEvents;	/**< length of FIFOEvent list */
-        FIFOEvent*  _events() { return reinterpret_cast<FIFOEvent*>(this+1); }
-        //EvrData::FIFOEvent	_fifoEvents[this->_u32NumFifoEvents];
-    };
-    class TimeToolDataV1 {
-    public:
-        uint32_t	_event_type;	/**< Event designation */
-        uint32_t	_z;
-        double	_amplitude;	/**< Amplitude of the edge */
-        double	_position_pixel;	/**< Filtered pixel position of the edge */
-        double	_position_time;	/**< Filtered time position of the edge */
-        double	_position_fwhm;	/**< Full-width half maximum of filtered edge (in pixels) */
-        double	_nxt_amplitude;	/**< Amplitude of the next largest edge */
-        double	_ref_amplitude;	/**< Amplitude of reference at the edge */
-        //int32_t	_average_signal[cfg.signal_average_size()];
+    //
+    //  Data types from LCLS-1
+    //
+    namespace PdsL1 {
+        class Xtc {
+        public:
+            char* payload() { return (char*)(this+1); }
+            uint32_t damage;
+            uint32_t src_log;
+            uint32_t src_phy;
+            uint32_t contains;
+            uint32_t extent;
+        };
+        class FrameV1 {
+        public:
+            uint16_t*   data() { return reinterpret_cast<uint16_t*>(this+1); }
+            uint16_t&   operator()(unsigned pix) { return data()[pix]; }
+            uint32_t	_pixels;	/**< Number of pixels. */
+            uint32_t	_depth;	/**< Number of bits per pixel. */
+            uint32_t	_offset;	/**< Fixed offset/pedestal value of pixel data. */
+            //uint8_t	_pixel_data[this->_pixels*((this->_depth+7)/8)];
+        };
+        class FIFOEvent {
+        public:
+            uint32_t	_timestampHigh;	/**< 119 MHz timestamp (fiducial) */
+            uint32_t	_timestampLow;	/**< 360 Hz timestamp */
+            uint32_t	_eventCode;	/**< event code (range 0-255) */
+        };
+        class EvrDataV4 {
+        public:
+            uint32_t	_u32NumFifoEvents;	/**< length of FIFOEvent list */
+            FIFOEvent*  _events() { return reinterpret_cast<FIFOEvent*>(this+1); }
+            //EvrData::FIFOEvent	_fifoEvents[this->_u32NumFifoEvents];
+        };
+        class TimeToolDataV1 {
+        public:
+            uint32_t	_event_type;	/**< Event designation */
+            uint32_t	_z;
+            double	_amplitude;	/**< Amplitude of the edge */
+            double	_position_pixel;	/**< Filtered pixel position of the edge */
+            double	_position_time;	/**< Filtered time position of the edge */
+            double	_position_fwhm;	/**< Full-width half maximum of filtered edge (in pixels) */
+            double	_nxt_amplitude;	/**< Amplitude of the next largest edge */
+            double	_ref_amplitude;	/**< Amplitude of reference at the edge */
+            //int32_t	_average_signal[cfg.signal_average_size()];
+        };
     };
 };
 
 static void _load_xtc(std::vector<uint8_t>&, const char*);
 
 
-using Drp::Piranha4;
-using Drp::Piranha4TTFex;
+using namespace Drp;
 using Drp::Piranha::TT;
+using Drp::Piranha::TTSim;
 using Drp::Piranha::TTSimL1;
 using Drp::Piranha::TTSimL2;
 

--- a/psdaq/drp/PvaDetector.cc
+++ b/psdaq/drp/PvaDetector.cc
@@ -123,26 +123,28 @@ struct DataDsc {
     void*    data;
 };
 
-class RawDef : public VarDef
-{
-public:
-    enum index { field };
-    RawDef(std::string& field, Name::DataType dType, int rank)
-    {
-        NameVec.push_back({field.c_str(), dType, rank});
-    }
-};
+    namespace {
+        class RawDef : public VarDef
+        {
+        public:
+            enum index { field };
+            RawDef(std::string& field, Name::DataType dType, int rank)
+            {
+                NameVec.push_back({field.c_str(), dType, rank});
+            }
+        };
 
-class InfoDef : public VarDef
-{
-public:
-    enum index { keys, detName };
-    InfoDef(std::string& detName)
-    {
-        NameVec.push_back({"keys",          Name::CHARSTR, 1});
-        NameVec.push_back({detName.c_str(), Name::CHARSTR, 1});
-    }
-};
+        class InfoDef : public VarDef
+        {
+        public:
+            enum index { keys, detName };
+            InfoDef(std::string& detName)
+            {
+                NameVec.push_back({"keys",          Name::CHARSTR, 1});
+                NameVec.push_back({detName.c_str(), Name::CHARSTR, 1});
+            }
+        };
+    };
 
 // ---
 


### PR DESCRIPTION
Discovered some sneaky class name collisions in file-local VarDef subclasses.