### PR TITLE
Tripper TEB plugin: Add Version with Event Selection

### DIFF
--- a/psdaq/psdaq/trigger/meson.build
+++ b/psdaq/psdaq/trigger/meson.build
@@ -32,6 +32,26 @@ mfxTripperTeb_lib = shared_library('mfxTripperTeb',
   install_rpath: libdir_install_rpath,
 )
 
+mfxTripperEvSelectTeb_lib = shared_library('mfxTripperEvSelectTeb',
+  [
+    'src/mfxTripperPrimitive.cc',
+    'src/mfxTripperPrimitive_jungfrau.cc',
+    'src/mfxTripperPrimitive_timing.cc',
+    'src/mfxTripperEvSelectTeb.cc',
+  ],
+  include_directories: [
+    trigger_inc_dir,
+    include_directories(join_paths(get_option('epics_base'), 'include')),
+  ],
+  dependencies: [
+    xtcdata_dep,
+    psalg_utils_dep,
+    epics_dep,
+  ],
+  install: true,
+  install_rpath: libdir_install_rpath,
+)
+
 tmoTrigger_lib = shared_library('tmoTrigger',
   [
     'src/TriggerPrimitiveExample_cam.cc',

--- a/psdaq/psdaq/trigger/mfxTripper_config_store.py
+++ b/psdaq/psdaq/trigger/mfxTripper_config_store.py
@@ -15,24 +15,25 @@ def usual_cdict():
     top.setAlg('tebConfig', [0,1,0])
 
     help_str  = "-- user --"
-    help_str += "\nsoname       : The trigger library the DRPs and TEBs are to use"
-    help_str += "\n               It is to be found in $TESTRELDIR"
-    help_str += "\npythonScript : Trigger script to run given a suitable trigger library"
-    help_str += "\n               Its path is given by the TEB's 'script_path' kwarg"
-    help_str += "\nbuildAll     : Event build all detector contributions vs only"
-    help_str += "\n               those listed in 'buildDets'"
-    help_str += "\nbuildDets    : Comma separated list of detNames to event build"
-    help_str += "\n               Ignored when buildAll is 0"
-    help_str += "\nprescale     : Record 1 in N events for which the persist trigger"
-    help_str += "\n               condition isn't met"
-    help_str += "\npersistValue : Trigger condition for recording an event"
-    help_str += "\nmonitorValue : Trigger condition for monitoring an event"
-    help_str += "\ntripBasePV   : Base PV for detector protection IOC (tripper)."
-    help_str += "\nrogRsrvdBuf  : Number of MEB event buffers to be held aside for"
-    help_str += "\n               events to which a slow readout group contributed"
+    help_str += "\nsoname          : The trigger library the DRPs and TEBs are to use"
+    help_str += "\n                  It is to be found in $TESTRELDIR"
+    help_str += "\npythonScript    : Trigger script to run given a suitable trigger library"
+    help_str += "\n                  Its path is given by the TEB's 'script_path' kwarg"
+    help_str += "\nbuildAll        : Event build all detector contributions vs only"
+    help_str += "\n                  those listed in 'buildDets'"
+    help_str += "\nbuildDets       : Comma separated list of detNames to event build"
+    help_str += "\n                  Ignored when buildAll is 0"
+    help_str += "\nprescale        : Record 1 in N events for which the persist trigger"
+    help_str += "\n                  condition isn't met"
+    help_str += "\npersistValue    : Trigger condition for recording an event"
+    help_str += "\nmonitorValue    : Trigger condition for monitoring an event"
+    help_str += "\ntripBasePV      : Base PV for detector protection IOC (tripper)."
+    help_str += "\nacceptEventCode : Only record and monitor data for this event code."
+    help_str += "\nrogRsrvdBuf     : Number of MEB event buffers to be held aside for"
+    help_str += "\n                  events to which a slow readout group contributed"
     top.set('help:RO', help_str, 'CHARSTR')
 
-    top.set('soname', 'libmfxTripperTeb.so', 'CHARSTR')
+    top.set('soname', 'libmfxTripperEvSelectTeb.so', 'CHARSTR')
 
     top.set('pythonScript', 'tebTstTrigger.py', 'CHARSTR')
 
@@ -43,7 +44,8 @@ def usual_cdict():
 
     top.set('persistValue', 0xdeadbeef, 'UINT32')
     top.set('monitorValue', 0x12345678, 'UINT32')
-    top.set('tripBasePV', 'MFX:EPIX:BLOCKER', 'CHARSTR')
+    top.set('tripBasePV', 'MFX:JF16M:BLOCKER', 'CHARSTR')
+    top.set('acceptEventCode', 0, 'UINT32')
 
     for rog in range(8):
         top.set(f'rogRsrvdBuf[{str(rog)}]', 0, 'UINT32')

--- a/psdaq/psdaq/trigger/src/CMakeLists.txt
+++ b/psdaq/psdaq/trigger/src/CMakeLists.txt
@@ -44,6 +44,26 @@ target_link_libraries(mfxTripperTeb
   epics::ca
 )
 
+add_library(mfxTripperEvSelectTeb SHARED
+  mfxTripperPrimitive.cc
+  mfxTripperPrimitive_jungfrau.cc
+  mfxTripperPrimitive_timing.cc
+  mfxTripperEvSelectTeb.cc
+)
+
+target_include_directories(mfxTripperEvSelectTeb PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include>
+  ${PYTHON_INCLUDE_DIRS}
+)
+
+target_link_libraries(mfxTripperEvSelectTeb
+  xtcdata::xtc
+  trigger
+  nlohmann_json::nlohmann_json
+  epics::ca
+)
+
 add_library(tmoTrigger SHARED
   TriggerPrimitiveExample_cam.cc
   TriggerPrimitiveExample_xpphsd.cc

--- a/psdaq/psdaq/trigger/src/TripperTebData.hh
+++ b/psdaq/psdaq/trigger/src/TripperTebData.hh
@@ -1,8 +1,8 @@
 #ifndef Pds_Trg_TripperTebData_hh
 #define Pds_Trg_TripperTebData_hh
+
+#include <algorithm>
 #include <cstdint>
-#include <stdint.h>
-#include <string>
 #include <cstring>
 
 namespace Pds
@@ -11,20 +11,43 @@ namespace Trg
 {
 #pragma pack(push,1)
 struct TripperTebData {
-    TripperTebData(const uint16_t _hotPixelThresh,
-                   const uint32_t _numHotPixels,
-                   const uint32_t _maxHotPixels,
+    TripperTebData(uint16_t _hotPixelThresh,
+                   uint32_t _numHotPixels,
+                   uint32_t _maxHotPixels,
                    const char* _detType)
-      : hotPixelThresh{_hotPixelThresh}
-      , numHotPixels{_numHotPixels}
-      , maxHotPixels{_maxHotPixels}
     {
-        memcpy(detType, _detType, strlen(_detType));
+        new (&smalldata) SmallData {
+            { _hotPixelThresh, _numHotPixels, _maxHotPixels }
+        };
+        size_t len = std::min(std::strlen(_detType), sizeof(detType) - 1);
+        std::memcpy(detType, _detType, len);
+        detType[len] = '\0';
     };
-    const uint16_t hotPixelThresh; ///< ADU Threshold for considering a pixel "hot"
-    const uint32_t numHotPixels; ///< Number of hot pixels found in this contribution
-    const uint32_t maxHotPixels; ///< Max number of hot pixels across ALL contributions before tripping
-    char detType[30]; ///< Detector type so TEB decides if contributes to tripping
+
+    TripperTebData(uint16_t* _seqInfo, const char* _detType)
+    {
+        new (&smalldata) SmallData{};
+        std::memcpy(smalldata.seqInfo, _seqInfo, sizeof(smalldata.seqInfo));
+
+        size_t len = std::min(std::strlen(_detType), sizeof(detType) - 1);
+        std::memcpy(detType, _detType, len);
+        detType[len] = '\0';
+    }
+
+    union SmallData {
+        // For the Jungfrau. Dummy contributions from unused detectors also use struct
+        struct {
+            uint16_t hotPixelThresh; ///< ADU Threshold for considering a pixel "hot"
+            uint32_t numHotPixels;   ///< Number of hot pixels found in this contribution
+            uint32_t maxHotPixels;   ///< Max number of hot pixels across ALL contributions before tripping
+        };
+        // For the timing detector
+        uint16_t seqInfo[18];       ///< Holds the event code/sequence info
+    } smalldata;
+
+    // Functions as the union tag. TEB uses to decide contribution to "tripping"
+    // or event code selection.
+    char detType[30];
 };
 #pragma pack(pop)
 }; // namespace Trg

--- a/psdaq/psdaq/trigger/src/mfxTripperEvSelectTeb.cc
+++ b/psdaq/psdaq/trigger/src/mfxTripperEvSelectTeb.cc
@@ -1,12 +1,10 @@
 #include "Trigger.hh"
 #include "TripperTebData.hh"
 
-#include "utilities.hh"
-
 #include <cadef.h>
+#include "nlohmann/json.hpp"
 
 #include <cstdint>
-#include <stdio.h>
 #include <iostream>
 #include <cstring>
 
@@ -15,6 +13,9 @@ using json = nlohmann::json;
 /**
  * TEB Trigger data for detector protection.
  * "Trips" shutter when number of hot pixels (ADU above a threshold) exceeds a count.
+ * This version (as opposed to `mfxTripperTeb.cc`) also allows for event code selection.
+ * If a non-zero event code is provided for `acceptEventCode` in the configDB, only
+ * data for that event code will be saved and monitored.
  */
 
 namespace Pds {
@@ -38,13 +39,15 @@ namespace Pds {
         }
     private:
         chid m_blockId; ///< Channel to trigger blocking of beam
-        chid m_aduId;  ///< ADU threshold to consider pixel "hot"
-        chid m_npixId; ///< Maximum number of hot pixels
-        chid m_npix_overId; ///< Number of hot pixels found
-        std::string m_tripperPV;
+        chid m_aduId;  ///< Channel for ADU threshold to consider pixel "hot"
+        chid m_npixId; ///< Channel for maximum number of hot pixels
+        chid m_npix_overId; ///< Channel for number of hot pixels found
+        std::string m_tripperPV; ///< Base PV for the above channels
         bool m_tripped {false};
         bool m_printTrippedWarning {true};
         ca_client_context* m_context;
+
+        uint32_t m_evt_code{0};
     };
     };
 };
@@ -63,6 +66,15 @@ int Pds::Trg::MfxTripperTrigger::configure(const json&              connectMsg,
         std::cout << "Configuration requires tripBasePV to work! Check configdb!" << std::endl;
         return 1;
     }
+
+    if (top.contains("acceptEventCode")) {
+        m_evt_code = top["acceptEventCode"].get<uint32_t>();
+        std::cout << "Will only accept events with event code: " << m_evt_code << std::endl;
+    } else {
+        std::cerr << "Configuration requires acceptEventCode to work! Check configdb!" << std::endl;
+        return 1;
+    }
+
     SEVCHK(ca_context_create(ca_enable_preemptive_callback), "ca_context_create failed!");
     m_context = ca_current_context();
     int status;
@@ -123,6 +135,15 @@ void Pds::Trg::MfxTripperTrigger::event(const Pds::EbDgram* const* start,
             maxHotPixels = data->smalldata.maxHotPixels;
             hotPixelThresh = data->smalldata.hotPixelThresh;
             foundJungfrau = true;
+        }
+
+        if (m_evt_code && strcmp(data->detType, "timing") == 0) {
+            // If we assigned an event code, check that it was present
+            if (!(data->smalldata.seqInfo[m_evt_code >> 4] & (1 << (m_evt_code & 0xF)))) {
+                // If the event code is not present do not write or monitor
+                wrt = false;
+                mon = false;
+            }
         }
     } while (++ctrb != end);
 

--- a/psdaq/psdaq/trigger/src/mfxTripperPrimitive_timing.cc
+++ b/psdaq/psdaq/trigger/src/mfxTripperPrimitive_timing.cc
@@ -1,0 +1,69 @@
+#include "TriggerPrimitive.hh"
+#include "TripperTebData.hh"
+
+#include "drp/TimingDef.hh"
+#include "drp/drp.hh"
+
+#include "xtcdata/xtc/Damage.hh"
+#include "xtcdata/xtc/Dgram.hh"
+#include "xtcdata/xtc/ShapesData.hh"
+#include "xtcdata/xtc/ConfigIter.hh"
+
+#include "nlohmann/json.hpp"
+
+#include <cstdint>
+
+using json = nlohmann::json;
+
+
+namespace Pds {
+  namespace Trg {
+
+    class MfxTripperPrimitive_timing : public TriggerPrimitive
+    {
+    public:
+        int    configure(const json& configureMsg,
+                         const json& connectMsg,
+                         size_t      collectionId) override;
+        void   event(const Drp::MemPool& pool,
+                     uint32_t            idx,
+                     const XtcData::Xtc& ctrb,
+                     XtcData::Xtc&       xtc,
+                     const void*         bufEnd) override;
+        size_t size() const  { return sizeof(TripperTebData); }
+    };
+  };
+};
+
+
+using namespace Pds::Trg;
+
+int Pds::Trg::MfxTripperPrimitive_timing::configure(const json& configureMsg,
+                                                    const json& connectMsg,
+                                                    size_t      collectionId)
+{
+    return 0;
+}
+
+void Pds::Trg::MfxTripperPrimitive_timing::event(const Drp::MemPool& pool,
+                                                 uint32_t            idx,
+                                                 const XtcData::Xtc& ctrb,
+                                                 XtcData::Xtc&       xtc,
+                                                 const void*         bufEnd)
+{
+    XtcData::Xtc& shapesData = *reinterpret_cast<XtcData::Xtc*>(ctrb.payload());
+    XtcData::Xtc& data = *reinterpret_cast<XtcData::Xtc*>(shapesData.payload());
+
+    Drp::TimingData& timingData = *new (data.payload()) Drp::TimingData;
+
+    uint16_t* seqInfo = reinterpret_cast<uint16_t*>(timingData.sequenceValues);
+
+    new (xtc.alloc(sizeof(TripperTebData), bufEnd)) TripperTebData(seqInfo, "timing");
+}
+
+// The class factory
+
+extern "C" Pds::Trg::TriggerPrimitive* create_producer_timing()
+{
+    return new Pds::Trg::MfxTripperPrimitive_timing;
+}


### PR DESCRIPTION
This plugin provides the current MFX detector protection mechanism for the Jungfrau ("detector tripper"). On top of this, it adds the option to do event vetoing/filtering. This has been used to only record events at low rate while leaving the DAQ triggering in its normal 120 Hz configuration. This prevents the need for setting up new calibration constants for the Jungfrau detector for the different rate operation. The old TEB plugin (without the veto feature) is maintained as a separate library.