### PR TITLE
Use builtin cd for RELDIR assignment

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -73,8 +73,7 @@ elif [ -n "$ZSH_VERSION" ]; then
     SCRIPT_SOURCE="${(%):-%x}"
 fi
 
-#RELDIR="$( cd "$( dirname $(readlink -f "${BASH_SOURCE[0]:-${(%):-%x}}") )" && pwd )"
-RELDIR="$(cd "$(dirname "$(readlink -f "$SCRIPT_SOURCE")")" && pwd)"
+RELDIR="$(builtin cd "$(dirname "$(readlink -f "$SCRIPT_SOURCE")")" && pwd)"
 
 export PATH=$RELDIR/install/bin:${PATH}
 echo $RELDIR


### PR DESCRIPTION
Problem
setup_env.sh derive `RELDIR using: RELDIR="$(cd "$(dirname "$(readlink -f "$SCRIPT_SOURCE")")" && pwd)" `

This pattern is correct in a clean shell, but breaks when a user has overridden cd in their ~/.bashrc — a common recipe for running a command after every directory change, e.g.: 
```
function cd {
    builtin cd "$@" || return $?
    [ -t 1 ] && ls -lrt
    return 0
}
```

In Bash, shell functions take precedence over builtins. When the script is sourced into the user's interactive shell, the subshell $(...) inherits the user's cd function. 

Fix
Replace cd with builtin cd:
RELDIR="$(builtin cd "$(dirname "$(readlink -f "$SCRIPT_SOURCE")")" && pwd)" builtin is a Bash keyword that bypasses function lookup entirely and calls the real shell builtin directly. It cannot be overridden by any user-defined function, making RELDIR detection robust regardless of what a user has in their .bashrc.