### PR TITLE
Updated setup_env and buil_all scripts for S3DF

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -17,8 +17,16 @@ compile_only=0
 build_daq=0
 build_jobs=8
 
-if [ -d "/cds/sw/" ]; then
+if [[ -z "${ENV_TYPE+x}" ]]; then
+  echo "Please source setup_env.sh or setup_daq.sh"
+  echo "Exiting"
+  exit 1
+fi
+
+echo "Building analysis software"
+if [[ "${ENV_TYPE:-}" == "daq" ]]; then
   build_daq=1
+  echo "Building DAQ software"
 fi
 
 while getopts "fdcj:" opt; do
@@ -37,7 +45,7 @@ while getopts "fdcj:" opt; do
   esac
 done
 
-echo "INSTDIR:" $INSTDIR
+echo "Installation directory:" $INSTDIR
 
 if [ $force_clean == 1 ]; then
   echo "force_clean"

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -7,6 +7,8 @@ unset AMI_CONDA_PREFIX
 unset AMI_CONDA_DEFAULT_ENV
 unset AMI_TESTRELDIR
 
+export ENV_TYPE=legacy
+
 if [ -d "/cds/sw/" ]; then
     # for psana
     source /cds/sw/ds/ana/conda2-v4/inst/etc/profile.d/conda.sh

--- a/setup_env_ana.sh
+++ b/setup_env_ana.sh
@@ -1,0 +1,48 @@
+unset LD_LIBRARY_PATH
+unset PYTHONPATH
+
+if [[ "${ENV_TYPE:-}" == "daq" ]]; then
+  echo "Please do not mix ana and daq setup scripts"
+  echo "You sourced the ${ENV_TYPE} script befores"
+  echo "Exiting"
+  return 1
+fi
+export ENV_TYPE=ana
+
+unset LD_LIBRARY_PATH
+
+source /sdf/group/lcls/ds/ana/sw/conda2-v6/inst/etc/profile.d/conda.sh
+export CONDA_ENVS_DIRS=/sdf/group/lcls/ds/ana/sw/conda2/inst/envs
+export DIR_PSDM=/sdf/group/lcls/ds/ana/
+export SIT_PSDM_DATA=/sdf/data/lcls/ds/
+
+conda activate ps_20241122
+
+# In ASC lab the command for zsh does not work, but in XPP it does.
+# So we need to check which shell we are in to get the correct path to the script
+if [ -n "$BASH_VERSION" ]; then
+    SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+elif [ -n "$ZSH_VERSION" ]; then
+    SCRIPT_SOURCE="${(%):-%x}"
+fi
+
+RELDIR="$(cd "$(dirname "$(readlink -f "$SCRIPT_SOURCE")")" && pwd)"
+export PATH=$RELDIR/install/bin:${PATH}
+pyver=$(python -V 2>&1 | grep -oP '\d+\.\d+' | head -1)
+export PYTHONPATH=$RELDIR/install/lib/python$pyver/site-packages
+export TESTRELDIR=$RELDIR/install
+
+# cpo: seems that in more recent versions blas is creating many threads
+export OPENBLAS_NUM_THREADS=1
+export OMP_NUM_THREADS=1
+export NUMEXPR_NUM_THREADS=1
+# cpo: getting intermittent file-locking issue on ffb, so try this
+export HDF5_USE_FILE_LOCKING=FALSE
+# for libfabric. decreases performance a little, but allows forking
+export RDMAV_FORK_SAFE=1
+export RDMAV_HUGEPAGES_SAFE=1
+
+PS_PARALLEL='none'
+
+# needed by JupyterLab
+export JUPYTERLAB_WORKSPACES_DIR=${HOME}

--- a/setup_env_daq.sh
+++ b/setup_env_daq.sh
@@ -1,0 +1,73 @@
+unset LD_LIBRARY_PATH
+unset PYTHONPATH
+
+if [[ "${ENV_TYPE:-}" == "ana" ]]; then
+  echo "Please do not mix ana and daq setup scripts"
+  echo "You sourced the ${ENV_TYPE} script befores"
+  echo "Exiting"
+  return 1
+fi
+export ENV_TYPE=daq
+
+unset LD_LIBRARY_PATH
+unset PYTHONPATH
+
+source /sdf/group/lcls/ds/ana/sw/conda2-v6/inst/etc/profile.d/conda.sh
+export CONDA_ENVS_DIRS=/sdf/group/lcls/ds/ana/sw/conda2/inst/envs
+export DIR_PSDM=/sdf/group/lcls/ds/ana/
+
+conda activate daq_20250402_r9
+
+AUTH_FILE=$DIR_PSDM"/sw/conda2/auth.sh"
+if [ -f "$AUTH_FILE" ]; then
+    source $AUTH_FILE
+else
+  echo "$AUTH_FILE file is missing"
+fi
+
+export CUDA_ROOT=/usr/local/cuda
+if [ -h "$CUDA_ROOT" ]; then
+    export PATH=${CUDA_ROOT}/bin${PATH:+:${PATH}}
+    export LD_LIBRARY_PATH=${CUDA_ROOT}/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+    export MANPATH=${CUDA_ROOT}/man${MANPATH:+:${MANPATH}}
+fi
+
+# In ASC lab the command for zsh does not work, but in XPP it does.
+# So we need to check which shell we are in to get the correct path to the script
+if [ -n "$BASH_VERSION" ]; then
+    SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+elif [ -n "$ZSH_VERSION" ]; then
+    SCRIPT_SOURCE="${(%):-%x}"
+fi
+
+RELDIR="$(builtin cd "$(dirname "$(readlink -f "$SCRIPT_SOURCE")")" && pwd)"
+
+export PATH=$RELDIR/install/bin:${PATH}
+pyver=$(python -V 2>&1 | grep -oP '\d+\.\d+' | head -1)
+export PYTHONPATH=$RELDIR/install/lib/python$pyver/site-packages
+export TESTRELDIR=$RELDIR/install
+
+export PROCMGR_EXPORT=RDMAV_FORK_SAFE=1,RDMAV_HUGEPAGES_SAFE=1  # See fi_verbs man page regarding fork()
+export PROCMGR_EXPORT=$PROCMGR_EXPORT,OPENBLAS_NUM_THREADS=1,OMP_NUM_THREADS=1,NUMEXPR_NUM_THREADS=1,PS_PARALLEL='none'
+
+# for daqbatch
+export DAQMGR_EXPORT=RDMAV_FORK_SAFE=1,RDMAV_HUGEPAGES_SAFE=1  # See fi_verbs man page regarding fork()
+export DAQMGR_EXPORT=$DAQMGR_EXPORT,OPENBLAS_NUM_THREADS=1,OMP_NUM_THREADS=1,NUMEXPR_NUM_THREADS=1,PS_PARALLEL='none'
+
+# cpo: seems that in more recent versions blas is creating many threads
+export OPENBLAS_NUM_THREADS=1
+export OMP_NUM_THREADS=1
+export NUMEXPR_NUM_THREADS=1
+# cpo: getting intermittent file-locking issue on ffb, so try this
+export HDF5_USE_FILE_LOCKING=FALSE
+# for libfabric. decreases performance a little, but allows forking
+export RDMAV_FORK_SAFE=1
+export RDMAV_HUGEPAGES_SAFE=1
+
+PS_PARALLEL='none'
+
+# needed by JupyterLab
+export JUPYTERLAB_WORKSPACES_DIR=${HOME}
+
+# needed by Ric to get correct libfabric man pages
+export MANPATH=$CONDA_PREFIX/share/man${MANPATH:+:${MANPATH}}


### PR DESCRIPTION
This PR splits the `setup_env.sh` script in two scripts: one for the DAQ and one for analysis

Additionally the build_all script has been modified to make sure that one of the two scripts has been sourced and to build the daq when the `setup_env_daq.sh` has been sourced.

The old `setup_env.sh` is left in for backward compatibility but should not be used