### PR TITLE
gpu: fix slot retirement and pipeline automatic D2H

### DIFF
--- a/psana/psana/debugtools/ds_count_events.py
+++ b/psana/psana/debugtools/ds_count_events.py
@@ -21,6 +21,7 @@ Other options:
     --detectors q_atmopal rix_fim0
     --gpu_det jungfrau
     --gpu_pool_depth 2
+    --gpu_d2h_chunk_size 2
     --gpu_d2h_interval 1000
     --max_events 10000
     --log_level INFO
@@ -55,6 +56,8 @@ def parse_args():
     parser.add_argument('--gpu_pool_depth', '--n_gpu_streams',
                         dest='n_gpu_streams', type=int, default=None,
                         help='GPU EventPool depth / DataSource(n_gpu_streams=...)')
+    parser.add_argument('--gpu_d2h_chunk_size', type=int, default=0,
+                        help='Async D2H chunk size / DataSource(gpu_d2h_chunk_size=...) (0=disabled)')
     parser.add_argument('--gpu_d2h_interval', type=int, default=0,
                         help='Call ctx.get("calib").on_cpu every N events in GPU mode (0=never)')
     parser.add_argument('--max_events', type=int, default=0, help='Max number of events per rank (0=all)')
@@ -97,6 +100,7 @@ def create_datasource(args, rank):
         common_kwargs["skip_calib_load"] = args.skip_calib_load
     if args.gpu_det:
         common_kwargs["gpu_det"] = args.gpu_det
+        common_kwargs["gpu_d2h_chunk_size"] = args.gpu_d2h_chunk_size
         if args.n_gpu_streams is not None:
             common_kwargs["n_gpu_streams"] = args.n_gpu_streams
 

--- a/psana/psana/debugtools/gpu_slot_overwrite_repro.py
+++ b/psana/psana/debugtools/gpu_slot_overwrite_repro.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python
+"""Reproduce late-consumer registration overwriting a GPU execution slot.
+
+This is a diagnostic for the current GPU DataSource iterator ordering.  It
+uses a pool depth and batch size of one, disables automatic D2H, and launches
+a deliberately delayed external CUDA consumer for event 0.  Advancing the
+normal ``run.events()`` iterator submits event 1 into the same calibration
+slot before the external consumer's completion event is honored.
+
+The normal Jungfrau path assembles calibration into a newly allocated full
+detector array during routing.  That allocation masks execution-slot reuse,
+so this diagnostic monkey-patches only ``_apply_full_routing`` to return the
+underlying slot-backed calibration view.  DataSource, EventPool, GPUDetector,
+SlotLease, ``on_gpu_view()``, and the event iterator remain unchanged.
+
+Expected result on the affected implementation::
+
+    slot pointers match:       True
+    event 0 before != after:   True
+    event 0 after == event 1:  True
+    RESULT: OVERWRITE REPRODUCED
+
+Run with three MPI ranks (SMD0, EB, BD/GPU), for example::
+
+    mpirun -n 3 python -u \
+      psana/psana/debugtools/gpu_slot_overwrite_repro.py \
+      --exp mfx100848724 --run 51 \
+      --dir /sdf/data/lcls/ds/prj/public01/xtc
+"""
+
+import argparse
+import sys
+
+from mpi4py import MPI
+
+
+_PROBE_SOURCE = r"""
+extern "C" __global__
+void psana_slot_overwrite_probe(
+    const volatile unsigned int* src,
+    unsigned long long n_words,
+    unsigned long long n_samples,
+    unsigned long long delay_cycles,
+    unsigned long long* hashes)
+{
+    if (blockIdx.x != 0 || threadIdx.x != 0) return;
+
+    unsigned long long count = n_samples < n_words ? n_samples : n_words;
+    unsigned long long step = 11400714819323198485ULL;
+    unsigned long long h0 = 1469598103934665603ULL;
+    for (unsigned long long i = 0; i < count; ++i) {
+        unsigned long long idx = (i * step) % n_words;
+        h0 ^= (unsigned long long)src[idx];
+        h0 *= 1099511628211ULL;
+    }
+    hashes[0] = h0;
+
+    unsigned long long started = clock64();
+    while (clock64() - started < delay_cycles) {
+        // The repeated clock64() hardware reads keep this polling loop from
+        // being optimized away.  Do not use inline PTX "nop": it is not a
+        // recognized PTX instruction in the CUDA 12 NVRTC toolchain.
+    }
+
+    // src is volatile so these are fresh global-memory loads after the delay.
+    unsigned long long h1 = 1469598103934665603ULL;
+    for (unsigned long long i = 0; i < count; ++i) {
+        unsigned long long idx = (i * step) % n_words;
+        h1 ^= (unsigned long long)src[idx];
+        h1 *= 1099511628211ULL;
+    }
+    hashes[1] = h1;
+}
+"""
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(
+        description="Reproduce EventPool slot overwrite after late consumer registration."
+    )
+    parser.add_argument("--exp", required=True)
+    parser.add_argument("--run", required=True, type=int)
+    parser.add_argument("--dir", default=None)
+    parser.add_argument("--gpu-det", default="jungfrau")
+    parser.add_argument("--delay-cycles", type=int, default=500_000_000,
+                        help="GPU probe delay in SM clock cycles (default: 500M)")
+    parser.add_argument("--samples", type=int, default=65_536,
+                        help="Number of float32 words included in each hash")
+    parser.add_argument("--log-level", default="WARNING")
+    parser.add_argument(
+        "--expect", choices=("overwrite", "safe"), default="overwrite",
+        help="Expected outcome; use 'safe' to validate the retirement fix",
+    )
+    return parser.parse_args()
+
+
+def _disable_full_routing_copy():
+    """Expose GPUDetector's execution-slot view through the normal context."""
+    import psana.gpu.gpu_events as gpu_events
+
+    def identity_routing(gpu_results, evt, gpu_detectors, router):
+        return gpu_results
+
+    gpu_events._apply_full_routing = identity_routing
+
+
+def _hash_now(cp, kernel, arr, samples):
+    hashes = cp.zeros(2, dtype=cp.uint64)
+    words = arr.view(cp.uint32).ravel()
+    kernel(
+        (1,),
+        (1,),
+        (words, words.size, samples, 0, hashes),
+    )
+    cp.cuda.Stream.null.synchronize()
+    return int(hashes[0].item())
+
+
+def _run_probe(first_ctx, event_iter, args):
+    import cupy as cp
+
+    kernel = cp.RawKernel(_PROBE_SOURCE, "psana_slot_overwrite_probe")
+    probe_stream = cp.cuda.Stream(non_blocking=True)
+    hashes_gpu = cp.zeros(2, dtype=cp.uint64)
+
+    result0 = first_ctx.get("calib")
+    with result0.on_gpu_view(probe_stream) as arr0:
+        ptr0 = int(arr0.data.ptr)
+        words0 = arr0.view(cp.uint32).ravel()
+        with probe_stream:
+            kernel(
+                (1,),
+                (1,),
+                (words0, words0.size, args.samples,
+                 args.delay_cycles, hashes_gpu),
+            )
+
+    # Resuming the real iterator submits event 1 calibration into pool slot 0.
+    # Event 1 itself is yielded once event 2 causes that slot to retire again.
+    second_ctx = next(event_iter)
+    result1 = second_ctx.get("calib")
+    arr1 = result1._arr  # Diagnostic inspection of the execution-slot view.
+    ptr1 = int(arr1.data.ptr)
+
+    # The delayed event-0 consumer should now have observed event 1 in-place.
+    probe_stream.synchronize()
+    before0, after0 = (int(v) for v in hashes_gpu.get())
+    hash1 = _hash_now(cp, kernel, arr1, args.samples)
+
+    same_pointer = ptr0 == ptr1
+    changed_while_consumed = before0 != after0
+    after_matches_event1 = after0 == hash1
+    reproduced = same_pointer and changed_while_consumed and after_matches_event1
+
+    return {
+        "timestamp0": int(first_ctx.timestamp),
+        "timestamp1": int(second_ctx.timestamp),
+        "ptr0": ptr0,
+        "ptr1": ptr1,
+        "hash0_before": before0,
+        "hash0_after": after0,
+        "hash1": hash1,
+        "same_pointer": same_pointer,
+        "changed_while_consumed": changed_while_consumed,
+        "after_matches_event1": after_matches_event1,
+        "reproduced": reproduced,
+    }
+
+
+def main():
+    args = _parse_args()
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+
+    _disable_full_routing_copy()
+
+    from psana import DataSource
+
+    ds = DataSource(
+        exp=args.exp,
+        run=args.run,
+        dir=args.dir,
+        gpu_det=args.gpu_det,
+        n_gpu_streams=1,
+        gpu_d2h_chunk_size=0,
+        batch_size=1,
+        max_events=3,
+        log_level=args.log_level,
+    )
+    run = next(ds.runs())
+    event_iter = iter(run.events())
+
+    local_result = None
+    try:
+        first_ctx = next(event_iter)
+    except StopIteration:
+        # SMD0/EB ranks participate in DataSource but do not receive user events.
+        pass
+    else:
+        local_result = _run_probe(first_ctx, event_iter, args)
+        # Drain the final event so all MPI roles terminate cleanly.
+        for _ in event_iter:
+            pass
+
+    gathered = comm.gather(local_result, root=0)
+    failure = 0
+    if rank == 0:
+        results = [r for r in gathered if r is not None]
+        if len(results) != 1:
+            print(f"ERROR: expected one BD/GPU result, got {len(results)}", flush=True)
+            failure = 2
+        else:
+            r = results[0]
+            print(f"timestamps:                {r['timestamp0']} -> {r['timestamp1']}")
+            print(f"slot pointers:             0x{r['ptr0']:x} -> 0x{r['ptr1']:x}")
+            print(f"event 0 hash before:       0x{r['hash0_before']:016x}")
+            print(f"event 0 hash after:        0x{r['hash0_after']:016x}")
+            print(f"event 1 hash:              0x{r['hash1']:016x}")
+            print(f"slot pointers match:       {r['same_pointer']}")
+            print(f"event 0 changed in use:    {r['changed_while_consumed']}")
+            print(f"event 0 after == event 1:  {r['after_matches_event1']}")
+            if r["reproduced"]:
+                print("RESULT: OVERWRITE REPRODUCED")
+            else:
+                print("RESULT: overwrite not observed")
+            expected = r["reproduced"] if args.expect == "overwrite" else not r["reproduced"]
+            if not expected:
+                print(f"ERROR: expected {args.expect} outcome")
+                failure = 1
+
+    failure = comm.bcast(failure, root=0)
+    return failure
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/psana/psana/gpu/context.py
+++ b/psana/psana/gpu/context.py
@@ -2,7 +2,7 @@
 psana/gpu/context.py — Per-event GPU result types.
 
 GPUResult
-    Wraps a GPU-resident CuPy array with lazy .on_gpu / .on_cpu access.
+    Wraps a detector result with explicit GPU / CPU accessors.
     Carries an optional SlotLease so downstream consumers can release the
     EventPool slot as soon as their D→H is done rather than holding it
     until the Python generator advances.
@@ -25,13 +25,13 @@ class SlotLease:
 
     Lifecycle
     ---------
-    1. EventPool.submit() queues calibration on ``stream``, records
-       ``calib_done`` immediately after all kernels, then creates one
-       SlotLease per event (sharing ``calib_done``, unique ``view``).
+    1. EventPool.submit() queues calibration and final routing on ``stream``,
+       records ``result_ready`` after that producer work, then creates one
+       SlotLease per (timestamp, result key), sharing ``result_ready``.
 
     2. GpuEvents._D2hPipeline receives the submitted slot record.  It issues
-       cudaMemcpyAsync on a separate D→H stream after waiting for calib_done,
-       then records d2h_done and calls register_d2h_done(event).
+       cudaMemcpyAsync on a separate D→H stream after waiting for result_ready,
+       then records a completion event and calls register_consumer_done(event).
 
     3. EventPool.begin_retire_next() exposes the result and its prepared host
        token.  After the caller has had a chance to register any external GPU
@@ -41,35 +41,36 @@ class SlotLease:
     has completed — generator advancement alone is not sufficient.
     """
 
-    __slots__ = ('calib_done', '_d2h_done')
+    __slots__ = ('result_ready', '_consumer_done')
 
-    def __init__(self, calib_done):
+    def __init__(self, result_ready):
         """
         Parameters
         ----------
-        calib_done : cp.cuda.Event — fires after calibration kernel completes
+        result_ready : cp.cuda.Event
+            Fires after calibration and final result-routing work completes.
         """
-        self.calib_done = calib_done
-        self._d2h_done  = None   # set by _D2hPipeline or _GpuViewContext.__exit__
+        self.result_ready = result_ready
+        self._consumer_done = None
 
-    def register_d2h_done(self, event):
+    def register_consumer_done(self, event):
         """Record the CUDA event that fires when this slot's consumer is done.
 
         Called by _D2hPipeline after issuing cudaMemcpyAsync, or by
         _GpuViewContext.__exit__ after the user's downstream GPU kernel.
         EventPool waits on this event in finish_retire_next() before reuse.
         """
-        self._d2h_done = event
+        self._consumer_done = event
 
     def wait_until_safe_to_reuse(self):
         """Block until the consumer has completed during final retirement.
 
         Two outcomes:
-          _d2h_done set  → synchronize then recycle
+          _consumer_done set  → synchronize then recycle
           neither        → recycle immediately (on_gpu copy or no access)
         """
-        if self._d2h_done is not None:
-            self._d2h_done.synchronize()
+        if self._consumer_done is not None:
+            self._consumer_done.synchronize()
 
 
 class _GpuViewContext:
@@ -103,25 +104,25 @@ class _GpuViewContext:
         stream = self._stream or cp.cuda.Stream.null
         done   = cp.cuda.Event(disable_timing=True)
         stream.record(done)
-        self._lease.register_d2h_done(done)
+        self._lease.register_consumer_done(done)
         self._exited = True
 
     def __del__(self):
         # Safety: if the object is GC'd without having been used as a context
         # manager, record a conservative done-event on the null stream so the
         # slot is not held forever.  Same pattern as _PendingD2H.__del__.
-        if not self._exited and self._lease._d2h_done is None:
+        if not self._exited and self._lease._consumer_done is None:
             try:
                 import cupy as cp
                 done = cp.cuda.Event(disable_timing=True)
                 cp.cuda.Stream.null.record(done)
-                self._lease.register_d2h_done(done)
+                self._lease.register_consumer_done(done)
             except Exception:
                 pass
 
 
 class GPUResult:
-    """GPU-resident detector result with lazy D→H transfer.
+    """Detector result with explicit device and cached host access.
 
     Returned by GpuEventContext.get('det.result').
 
@@ -131,20 +132,20 @@ class GPUResult:
         Calibrated array on device.  Never triggers a D→H transfer.
     on_cpu : np.ndarray
         Host copy.  If GpuEvents has already transferred this result via
-        its internal D→H pipeline (gpu_d2h_chunk_size > 0), returns the
-        pre-populated pinned numpy array immediately with no synchronisation.
-        Otherwise synchronises the production stream on first access.
+        its internal D→H pipeline (gpu_d2h_chunk_size > 0), waits for that
+        token when necessary and caches an independent NumPy result. Otherwise
+        performs one blocking D→H on first access and caches the result.
     _lease : SlotLease | None
         Slot ownership token.  Used by GpuEvents._D2hPipeline to issue
         direct async D→H from the slot view and signal when the slot is
         safe to recycle.  User code should not access _lease directly.
-    _pinned_cpu : np.ndarray | None
+    _cpu_cache : np.ndarray | None
         Cached independent CPU result.  Set either after GpuEvents' pinned
         D→H completes or by the synchronous fallback.  When set, on_cpu
         returns it without another GPU transfer.
     """
 
-    __slots__ = ('_arr', '_lease', '_pinned_cpu', '_pending_d2h',
+    __slots__ = ('_arr', '_lease', '_cpu_cache', '_pending_d2h',
                  '_device_released')
 
     def __init__(self, arr_gpu, lease=None, device_released=False):
@@ -156,7 +157,7 @@ class GPUResult:
         """
         self._arr         = arr_gpu
         self._lease       = lease
-        self._pinned_cpu  = None
+        self._cpu_cache   = None
         # Set by _D2hPipeline immediately after issuing async D→H.
         # Carries the CUDA done-event + pinned-slot reference so on_cpu
         # can wait lazily rather than blocking inside the generator.
@@ -224,27 +225,27 @@ class GPUResult:
 
         Three paths in priority order:
 
-        1. _pinned_cpu already set  → return immediately (free).
+        1. _cpu_cache already set   → return immediately (free).
         2. _pending_d2h set         → wait for the async D→H that
            _D2hPipeline issued before yielding this event, then copy
-           from the pinned slot and cache in _pinned_cpu.
+           from the pinned slot and cache in _cpu_cache.
         3. Fallback                 → call arr.get() (blocking D→H at the
            call site), cache the independent NumPy result, and return it.
         """
-        if self._pinned_cpu is not None:
-            return self._pinned_cpu
+        if self._cpu_cache is not None:
+            return self._cpu_cache
         if self._pending_d2h is not None:
-            self._pinned_cpu  = self._pending_d2h.get()
+            self._cpu_cache   = self._pending_d2h.get()
             self._pending_d2h = None
-            return self._pinned_cpu
+            return self._cpu_cache
         if self._device_released or self._arr is None:
             raise RuntimeError(
                 "on_cpu has no host result after the EventPool device slot "
                 "was released; this indicates an incomplete automatic-D2H "
                 "handoff."
             )
-        self._pinned_cpu = self._arr.get()
-        return self._pinned_cpu
+        self._cpu_cache = self._arr.get()
+        return self._cpu_cache
 
     def __repr__(self) -> str:
         shape = getattr(self._arr, 'shape', '?')
@@ -264,7 +265,7 @@ class GpuEventContext:
     """
 
     __slots__ = ('_evt', '_gpu_results', '_cpu_dets', '_cache', '_router',
-                 '_leases', '_pending_d2h', '_cpu_results',
+                 '_leases', '_pending_d2h', '_cached_cpu_results',
                  '_device_released')
 
     def __init__(self, evt, gpu_results: dict,
@@ -272,7 +273,7 @@ class GpuEventContext:
                  router=None,
                  leases: dict | None = None,
                  pending_d2h: dict | None = None,
-                 cpu_results: dict | None = None,
+                 cached_cpu_results: dict | None = None,
                  device_released: bool = False):
         """
         Parameters
@@ -286,7 +287,7 @@ class GpuEventContext:
             Attached to GPUResult objects in get().
         pending_d2h : dict  {key: _PendingD2H} | None
             Host-result tokens armed immediately after slot submission.
-        cpu_results : dict  {key: np.ndarray} | None
+        cached_cpu_results : dict  {key: np.ndarray} | None
             Independent CPU results materialized under pinned-buffer pressure.
         """
         self._evt         = evt
@@ -295,7 +296,7 @@ class GpuEventContext:
         self._router      = router
         self._leases      = leases or {}
         self._pending_d2h = pending_d2h or {}
-        self._cpu_results = cpu_results or {}
+        self._cached_cpu_results = cached_cpu_results or {}
         self._device_released = device_released
         self._cache: dict = {}
 
@@ -332,7 +333,7 @@ class GpuEventContext:
                 device_released=self._device_released,
             )
             result._pending_d2h = self._pending_d2h.get(resolved)
-            result._pinned_cpu = self._cpu_results.get(resolved)
+            result._cpu_cache = self._cached_cpu_results.get(resolved)
             self._cache[resolved] = result
         return self._cache[resolved]
 

--- a/psana/psana/gpu/context.py
+++ b/psana/psana/gpu/context.py
@@ -10,7 +10,8 @@ GPUResult
 SlotLease
     Completion token linking one event's calibrated output view to the
     EventPool slot it was produced in.  Created by EventPool.submit(),
-    attached to GPUResult, consumed by GpuEvents._D2hPipeline.
+    consumed immediately by GpuEvents._D2hPipeline for automatic D→H, and
+    attached to GPUResult when the event is later delivered.
 
 GpuEventContext
     Per-event container returned by DataSource(gpu_det=...).
@@ -28,14 +29,13 @@ class SlotLease:
        ``calib_done`` immediately after all kernels, then creates one
        SlotLease per event (sharing ``calib_done``, unique ``view``).
 
-    2. GpuEvents._D2hPipeline receives the lease via GPUResult._lease.
-       It issues cudaMemcpyAsync on a separate D→H stream after
-       waiting for calib_done, then records d2h_done and calls
-       register_d2h_done(event).
+    2. GpuEvents._D2hPipeline receives the submitted slot record.  It issues
+       cudaMemcpyAsync on a separate D→H stream after waiting for calib_done,
+       then records d2h_done and calls register_d2h_done(event).
 
-    3. EventPool.begin_retire_next() exposes the completed result.
-       After the caller has had a chance to register its consumer,
-       finish_retire_next() calls wait_until_safe_to_reuse() before reuse.
+    3. EventPool.begin_retire_next() exposes the result and its prepared host
+       token.  After the caller has had a chance to register any external GPU
+       consumer, finish_retire_next() waits before reuse.
 
     Rule: a slot may be reused only after every consumer of that slot
     has completed — generator advancement alone is not sufficient.
@@ -144,9 +144,10 @@ class GPUResult:
         returns it without another GPU transfer.
     """
 
-    __slots__ = ('_arr', '_lease', '_pinned_cpu', '_pending_d2h')
+    __slots__ = ('_arr', '_lease', '_pinned_cpu', '_pending_d2h',
+                 '_device_released')
 
-    def __init__(self, arr_gpu, lease=None):
+    def __init__(self, arr_gpu, lease=None, device_released=False):
         """
         Parameters
         ----------
@@ -160,6 +161,18 @@ class GPUResult:
         # Carries the CUDA done-event + pinned-slot reference so on_cpu
         # can wait lazily rather than blocking inside the generator.
         self._pending_d2h = None   # _PendingD2H | None
+        # Automatic D2H contexts can outlive the EventPool device slot.  Keep
+        # that state explicit so stale slot-backed arrays are never exposed.
+        self._device_released = device_released
+
+    def _require_device_storage(self, accessor: str):
+        if self._device_released or self._arr is None:
+            raise RuntimeError(
+                f"{accessor} is unavailable because automatic D2H completed "
+                "and the EventPool device slot was released before this event "
+                "was yielded. Use on_cpu, or set gpu_d2h_chunk_size=0 for a "
+                "GPU consumer."
+            )
 
     @property
     def on_gpu(self):
@@ -169,6 +182,7 @@ class GPUResult:
         be recycled immediately after this call.  Use when the copy cost
         (~2 ms D→D for Jungfrau) is acceptable and simplicity is preferred.
         """
+        self._require_device_storage("on_gpu")
         return self._arr.copy()
 
     def on_gpu_view(self, stream=None):
@@ -190,10 +204,17 @@ class GPUResult:
         Raises RuntimeError if this GPUResult has no SlotLease (i.e. was not
         produced by EventPool.submit()) — use on_gpu (D→D copy) instead.
         """
+        self._require_device_storage("on_gpu_view")
         if self._lease is None:
             raise RuntimeError(
                 "on_gpu_view is not safe: this GPUResult has no SlotLease. "
                 "Use on_gpu (D→D copy) instead, which is always safe."
+            )
+        if self._pending_d2h is not None:
+            raise RuntimeError(
+                "on_gpu_view is unavailable after automatic D2H has been "
+                "scheduled. Use gpu_d2h_chunk_size=0 for a zero-copy GPU "
+                "consumer, or use on_gpu for an independent D→D copy."
             )
         return _GpuViewContext(self._arr, self._lease, stream)
 
@@ -216,6 +237,12 @@ class GPUResult:
             self._pinned_cpu  = self._pending_d2h.get()
             self._pending_d2h = None
             return self._pinned_cpu
+        if self._device_released or self._arr is None:
+            raise RuntimeError(
+                "on_cpu has no host result after the EventPool device slot "
+                "was released; this indicates an incomplete automatic-D2H "
+                "handoff."
+            )
         self._pinned_cpu = self._arr.get()
         return self._pinned_cpu
 
@@ -236,13 +263,17 @@ class GpuEventContext:
         ctx.service()          → int (TransitionId)
     """
 
-    __slots__ = ('_evt', '_gpu_results', '_cpu_dets',
-                 '_cache', '_router', '_leases')
+    __slots__ = ('_evt', '_gpu_results', '_cpu_dets', '_cache', '_router',
+                 '_leases', '_pending_d2h', '_cpu_results',
+                 '_device_released')
 
     def __init__(self, evt, gpu_results: dict,
                  cpu_dets: dict | None = None,
                  router=None,
-                 leases: dict | None = None):
+                 leases: dict | None = None,
+                 pending_d2h: dict | None = None,
+                 cpu_results: dict | None = None,
+                 device_released: bool = False):
         """
         Parameters
         ----------
@@ -253,12 +284,19 @@ class GpuEventContext:
         leases      : dict  {key: SlotLease} | None
             Per-key slot leases created by EventPool.submit().
             Attached to GPUResult objects in get().
+        pending_d2h : dict  {key: _PendingD2H} | None
+            Host-result tokens armed immediately after slot submission.
+        cpu_results : dict  {key: np.ndarray} | None
+            Independent CPU results materialized under pinned-buffer pressure.
         """
         self._evt         = evt
         self._gpu_results = gpu_results
         self._cpu_dets    = cpu_dets or {}
         self._router      = router
         self._leases      = leases or {}
+        self._pending_d2h = pending_d2h or {}
+        self._cpu_results = cpu_results or {}
+        self._device_released = device_released
         self._cache: dict = {}
 
     def get(self, key: str) -> GPUResult:
@@ -288,10 +326,14 @@ class GpuEventContext:
                     f"'{key}' resolved to '{resolved}' which is not available.  "
                     f"Available GPU keys: {available}"
                 )
-            self._cache[resolved] = GPUResult(
+            result = GPUResult(
                 self._gpu_results[resolved],
                 lease=self._leases.get(resolved),
+                device_released=self._device_released,
             )
+            result._pending_d2h = self._pending_d2h.get(resolved)
+            result._pinned_cpu = self._cpu_results.get(resolved)
+            self._cache[resolved] = result
         return self._cache[resolved]
 
     def raw(self, det_name: str):

--- a/psana/psana/gpu/context.py
+++ b/psana/psana/gpu/context.py
@@ -33,9 +33,9 @@ class SlotLease:
        waiting for calib_done, then records d2h_done and calls
        register_d2h_done(event).
 
-    3. EventPool.retire_next() calls wait_until_safe_to_reuse() on
-       every lease in the outgoing slot before synchronising the
-       calibration stream and recycling the slot.
+    3. EventPool.begin_retire_next() exposes the completed result.
+       After the caller has had a chance to register its consumer,
+       finish_retire_next() calls wait_until_safe_to_reuse() before reuse.
 
     Rule: a slot may be reused only after every consumer of that slot
     has completed — generator advancement alone is not sufficient.
@@ -57,12 +57,12 @@ class SlotLease:
 
         Called by _D2hPipeline after issuing cudaMemcpyAsync, or by
         _GpuViewContext.__exit__ after the user's downstream GPU kernel.
-        EventPool waits on this event in retire_next() before recycling the slot.
+        EventPool waits on this event in finish_retire_next() before reuse.
         """
         self._d2h_done = event
 
     def wait_until_safe_to_reuse(self):
-        """Block until the consumer has completed; called by EventPool.retire_next().
+        """Block until the consumer has completed during final retirement.
 
         Two outcomes:
           _d2h_done set  → synchronize then recycle
@@ -77,7 +77,7 @@ class _GpuViewContext:
 
     ``__enter__`` returns the raw slot-buffer array (zero-copy).
     ``__exit__`` records a CUDA done-event on *stream* so that
-    EventPool.retire_next() knows the slot is safe to recycle once
+    EventPool.finish_retire_next() knows the slot is safe to recycle once
     that event fires.
 
     ``__del__`` is a safety fallback: if the caller somehow receives

--- a/psana/psana/gpu/context.py
+++ b/psana/psana/gpu/context.py
@@ -139,8 +139,9 @@ class GPUResult:
         direct async D→H from the slot view and signal when the slot is
         safe to recycle.  User code should not access _lease directly.
     _pinned_cpu : np.ndarray | None
-        Set by GpuEvents._D2hPipeline after D→H completes.  When set,
-        on_cpu returns this directly without any further GPU transfer.
+        Cached independent CPU result.  Set either after GpuEvents' pinned
+        D→H completes or by the synchronous fallback.  When set, on_cpu
+        returns it without another GPU transfer.
     """
 
     __slots__ = ('_arr', '_lease', '_pinned_cpu', '_pending_d2h')
@@ -206,8 +207,8 @@ class GPUResult:
         2. _pending_d2h set         → wait for the async D→H that
            _D2hPipeline issued before yielding this event, then copy
            from the pinned slot and cache in _pinned_cpu.
-        3. Fallback                 → synchronise production stream and
-           call arr.get() (blocking D→H at the call site).
+        3. Fallback                 → call arr.get() (blocking D→H at the
+           call site), cache the independent NumPy result, and return it.
         """
         if self._pinned_cpu is not None:
             return self._pinned_cpu
@@ -215,7 +216,8 @@ class GPUResult:
             self._pinned_cpu  = self._pending_d2h.get()
             self._pending_d2h = None
             return self._pinned_cpu
-        return self._arr.get()
+        self._pinned_cpu = self._arr.get()
+        return self._pinned_cpu
 
     def __repr__(self) -> str:
         shape = getattr(self._arr, 'shape', '?')

--- a/psana/psana/gpu/docs/LAZY_SYNC_D2H.md
+++ b/psana/psana/gpu/docs/LAZY_SYNC_D2H.md
@@ -1,1284 +1,530 @@
-# Lazy-Sync D→H Design
+# Lazy-Sync D2H and GPU Slot Lifetime
 
-## Five design decisions
+## Status and scope
 
-Five decisions together make the design correct, safe, and performant:
+This document describes the implemented psana2 GPU result-lifetime model.
+The current implementation supports Jungfrau calibration and two result
+consumption modes:
 
-1. `on_gpu` always returns a D→D copy — safe by default, no lease needed
-2. `on_gpu_view(stream)` is the explicit fast path — zero-copy, context manager records done-event automatically
-3. Pool depth defaults to 2 — sufficient overlap for basic calib kernel
-4. `_GpuBudget` — simple committed-bytes counter prevents OOM before `cp.empty()`
-5. `_available: SimpleQueue` — one mechanism for free-slot counting, identity, and retrieval
+1. Automatic D2H, enabled with `gpu_d2h_chunk_size > 0`.
+2. External GPU consumption, selected with `gpu_d2h_chunk_size = 0`.
 
----
+These modes have different retirement ordering because they expose different
+result lifetimes. Automatic-D2H results can be detached from the execution
+slot before delivery. External GPU results remain slot-backed while the user
+registers downstream work.
 
-## The problem
+The central invariant is:
 
-GPU calibration results live in device VRAM.  To read them on the CPU you
-need a Device→Host (D→H) PCIe transfer (~13 ms per Jungfrau event).
+> An execution slot cannot be overwritten until every terminal consumer of
+> its current contents has completed.
 
-The naive approach blocks the event generator until the transfer is done,
-which stalls the GPU pipeline:
-
-```
-generator                           user loop
-─────────                           ─────────
-retire batch
-_yield_ready():
-  issue D→H ... wait ... wait ...   ← GPU idle during transfer
-  yield ctx  ──────────────────────► arr = ctx.get('det.calib').on_cpu
-submit next batch
-```
-
-## The solution: issue early, sync late
-
-Issue the D→H transfer the moment the calibration kernel completes,
-yield the event context immediately (before the transfer finishes),
-and let `on_cpu` do the wait only when the user actually asks for the data.
-
-```
-generator                           user loop
-─────────                           ─────────
-retire batch
-_yield_ready():
-  issue D→H ↓ async, returns ~0ms
-  yield ctx  ──────────────────────► ... user does other work ...
-submit next batch                  ► arr = ctx.get('det.calib').on_cpu
-                                         │
-                                         └─ wait for D→H here
-GPU calibrates next batch ◄──────────────── (D→H overlaps with GPU work)
-```
-
-The key shift: the sync point moves from the **generator** to the **call
-site**.  The GPU never idles waiting for PCIe.
+Advancing a Python generator is not a CUDA completion signal.
 
 ---
 
-## Why each piece of machinery exists
-
-Making async D→H work correctly is not free.  Each problem it creates
-requires a specific fix, and those fixes are the classes you see in the
-codebase.
-
-```
-PROBLEM 1: D→H blocks the generator for 13 ms
-──────────────────────────────────────────────
-  Naive:  [calib 2ms][wait 13ms][calib 2ms][wait 13ms] ...
-                      ↑ GPU idle; exceeds 8 ms per-event budget at 120 Hz
-
-  Fix:  issue D→H asynchronously, yield immediately, sync lazily at on_cpu
-  → _D2hPipeline + _pending_d2h + GPUResult.on_cpu
-  → This fix creates Problem 2.
-
-
-PROBLEM 2: async D→H needs page-locked (pinned) host memory
-────────────────────────────────────────────────────────────
-  cudaMemcpyAsync cannot write to ordinary numpy memory — the OS must
-  not page it out mid-transfer.  cudaMallocHost in the hot path is too slow.
-
-  Fix:  pre-allocate page-locked buffers at startup
-  → _PinnedSlot (2 per pipeline, pre-allocated in _D2hPipeline._init)
-  → This fix creates Problem 3.
-
-
-PROBLEM 3: on_cpu must know when the async transfer finished
-─────────────────────────────────────────────────────────────
-  The transfer runs on a separate CUDA stream.  We need a completion signal.
-
-  Fix:  CUDA event recorded after memcpyAsync; on_cpu synchronizes it
-  → _PinnedSlot.done_event  +  _PendingD2H.get()
-  → This fix creates Problem 4.
-
-
-PROBLEM 4: D→H reads from the VRAM slot; the next calibration writes to it
-───────────────────────────────────────────────────────────────────────────
-  Starting batch N+1 calibration into slot 0 while batch N's D→H is still
-  copying OUT of slot 0 silently corrupts data.
-
-  Fix:  two alternating VRAM slots; retire_next() waits for done_event
-        before recycling a slot
-  → EventPool(n=2)  +  retire_next()
-  → This fix creates Problem 5.
-
-
-PROBLEM 5: retire_next() and _D2hPipeline are in different classes
-───────────────────────────────────────────────────────────────────
-  The done_event lives on _PinnedSlot (host side).
-  retire_next() lives on EventPool (VRAM slot side).
-  They need to communicate.
-
-  Fix:  SlotLease bridges the two — _D2hPipeline calls
-        lease.register_d2h_done(pslot.done_event) and retire_next()
-        calls lease._d2h_done.synchronize()
-  → SlotLease
-
-
-PROBLEM 6: user wants zero-copy GPU access without a D→D copy (~2 ms)
-───────────────────────────────────────────────────────────────────────
-  on_gpu makes a safe copy but costs ~2 ms.  For a user kernel that only
-  reads the data once, the copy is waste.  But a raw view of the slot
-  buffer without any safety mechanism causes silent corruption when the
-  slot is recycled too soon.
-
-  Fix:  on_gpu_view(stream) context manager — __exit__ records a done_event
-        on the user's stream; retire_next() waits for it via the same
-        SlotLease mechanism (Problem 5's fix, reused)
-  → _GpuViewContext  (no new synchronization machinery needed)
-
-
-PROBLEM 7: one EB batch may need more VRAM than one slot can hold
-──────────────────────────────────────────────────────────────────
-  batch_size=500 events × 60 MB = 30 GB  >  17 GB per-slot budget.
-  Attempting to calibrate all 500 at once crashes cp.empty().
-
-  Fix:  split the EB batch into pieces that each fit the per-slot budget
-  → _split_subbatches()  +  GpuSubbatchView
-  → This fix creates Problem 8.
-
-
-PROBLEM 8: how do we know the per-slot VRAM budget?
-────────────────────────────────────────────────────
-  CuPy has no built-in allocation limit.  cp.empty() simply crashes
-  the MPI job with CUDA_ERROR_OUT_OF_MEMORY and no useful message.
-
-  Fix:  manual committed-bytes counter; raises a human-readable error
-        before the allocation, and tries pool flush first
-  → _GpuBudget  +  GpuMemoryPressureError
-```
-
-**Dependency chain in one line:**
-
-```
-async D→H
-  → pinned memory (_PinnedSlot)
-  → completion signal (CUDA done_event)
-  → separate VRAM slots (EventPool)
-  → slot-recycle safety (SlotLease + retire_next)
-  → zero-copy user access (on_gpu_view + _GpuViewContext)
-  → VRAM sizing (subbatches + _GpuBudget)
-```
-
-Removing async D→H and going back to blocking `arr.get()` would let you
-delete all of the above.  The code would be ~10 lines.  It would also be
-too slow to keep up with the 120 Hz LCLS-II beam rate.
-
----
-
-## Full pipeline
-
-```
-DataSource(gpu_det='jungfrau', n_gpu_streams=2, gpu_d2h_chunk_size=10,
-           gpu_memory_budget_gb=15)
-                │
-                ▼
-        GpuEvents.__init__()
-                │
-                ├─── _GpuBudget(15 GB)  ◄──── budget.reserve() before every cp.empty()
-                │         │                   GpuMemoryPressureError if over limit
-                │         ▼
-                │    KvikioGpuReader(n_slots=2, budget=budget)
-                │         │  raw input slot buffers: uint8, grow lazily
-                │         │
-                │    GPUDetector(n_slots=2, budget=budget)
-                │         │  calib_slot_bufs: float32, batch×segs×r×c
-                │
-                ├─── EventPool(n=2)
-                │         │  2 non-blocking CUDA streams
-                │         │  retire_next() syncs slot from 2 batches ago (instant)
-                │
-                ├─── SlotLease  ◄─── created per-event in EventPool.submit()
-                │         │  calib_done CUDA event (after kernel)
-                │         │  _d2h_done  CUDA event (after consumer)
-                │
-                └─── _D2hPipeline  ◄─── activated when gpu_d2h_chunk_size > 0
-                          │  _available: SimpleQueue[_PinnedSlot]
-                          │  _get_free_slot() calls get_nowait() — O(1), no scan
-                          │  _PinnedSlot.dec_ref() calls put(self) when slot freed
-                          │  issues async D→H, yields events immediately
-                          │  on_cpu syncs lazily at call site
-```
-
----
-
-## Three ways to get calibrated data
+## Configuration
 
 ```python
-# Choose based on use case:
-arr = ctx.get('jungfrau.calib').on_gpu                    # D→D copy  — safe, no ceremony
-with ctx.get('jungfrau.calib').on_gpu_view(stream) as arr: # zero-copy — fast, auto-release
-    ...
-arr = ctx.get('jungfrau.calib').on_cpu                    # D→H       — transparent, numpy
+ds = DataSource(
+    ...,
+    gpu_det="jungfrau",
+    n_gpu_streams=2,
+    gpu_d2h_chunk_size=2,
+    gpu_memory_budget_gb=15,
+)
 ```
 
-### `on_gpu` — safe D→D copy
+The controls have separate meanings:
 
-Returns an independent CuPy array.  The slot buffer can be recycled
-immediately — no lease, no `release_after`, no user ceremony.
+| Control | Meaning |
+|---|---|
+| `n_gpu_streams` | Number of reusable GPU execution slots (`EventPool` depth) |
+| `gpu_d2h_chunk_size` | Maximum events stored in one pinned-host D2H buffer; `0` disables automatic D2H |
+| `gpu_memory_budget_gb` | Per-BD committed device-memory limit |
+| `batch_size` | EventBuilder communication size, not an execution-slot capacity |
+
+`gpu_d2h_chunk_size` does **not** determine the number of GPU slots. For
+example, `n_gpu_streams=2, gpu_d2h_chunk_size=2` means two reusable execution
+slots and pinned D2H buffers that can hold up to two event results each.
+
+The `ds_count_events.py` option `--gpu_pool_depth` is an alias for
+`n_gpu_streams`. Its `--gpu_d2h_interval` option is a benchmark-consumer
+control: it calls `on_cpu()` once every N events and is not part of the
+DataSource scheduling policy.
+
+---
+
+## Ownership objects
+
+### `_EventSlot`: one occupied execution pipeline
+
+`EventPool.submit()` creates an `_EventSlot` record containing:
+
+- The reusable slot ID and its producer CUDA stream.
+- GPU results indexed by event timestamp.
+- CPU event objects for delivery.
+- One `SlotLease` per exposed result.
+- Pending pinned-host D2H tokens.
+- Independent CPU fallback results.
+
+The record remains owned by `EventPool` until final retirement. Result routing
+is enqueued on the producer stream before the shared result-ready event is
+recorded.
+
+### `SlotLease`: terminal-consumer completion
+
+Each result lease contains:
+
+- `result_ready`: the producer/result-ready CUDA event.
+- `_consumer_done`: the terminal-consumer CUDA event, when one is registered.
+
+Automatic D2H registers its copy-completion event. An external
+`on_gpu_view(stream)` consumer registers an event recorded after the user's
+kernel launches. `EventPool` waits for the registered event before reuse.
+
+### `_PinnedSlot`: bounded host retention
+
+Each automatic-D2H pipeline lazily allocates a bounded pool of page-locked
+host buffers. A pinned slot contains:
+
+- A NumPy view over CUDA pinned memory.
+- One D2H completion event.
+- A reference count for the event results stored in that buffer.
+- A reference to the pipeline's free-slot queue.
+
+The number of pinned slots is `max(2, n_gpu_streams)`. Each pinned slot can
+hold up to `gpu_d2h_chunk_size` event results.
+
+### `_PendingD2H`: one event's pinned result
+
+The token stores a pinned slot, row index, and segment count. Calling
+`_PendingD2H.get()`:
+
+1. Synchronizes the pinned slot's D2H completion event.
+2. Copies the event row into an independent pageable NumPy array.
+3. Decrements the pinned-slot reference count.
+4. Returns the pinned slot to the free queue when its last result is consumed.
+
+If the user never calls `on_cpu()`, token destruction releases the pinned-slot
+reference. The execution slot and pinned-host slot therefore have separate
+lifetimes.
+
+---
+
+## Producer and automatic-D2H scheduling
+
+Automatic D2H is armed when GPU work is submitted, not when the result is
+later yielded:
+
+```text
+producer stream:
+    H2D input is ready
+      -> calibration and final routing
+      -> record result-ready event
+
+D2H stream:
+    wait for result-ready event
+      -> cudaMemcpyAsync(slot result -> pinned host)
+      -> record D2H-done event
+      -> register D2H-done on SlotLease
+```
+
+`_D2hPipeline.schedule(slot_record)` schedules every matching result in the
+submitted execution slot. It divides the record into physical chunks no larger
+than `gpu_d2h_chunk_size`. A partial chunk is scheduled immediately; there is
+no cross-slot `_chunk_buf` and no batch-boundary D2H flush.
+
+For `batch_size=1, gpu_d2h_chunk_size=2`, each execution record contains one
+event, so a one-event partial D2H is issued for every event.
+
+---
+
+## Two retirement policies
+
+### Automatic D2H: `gpu_d2h_chunk_size > 0`
+
+Automatic D2H is the CPU-result mode. The normal slot-replacement path is:
+
+```text
+submit event N in slot S
+  -> calibration/routing
+  -> schedule D2H immediately
+  -> D2H completes into pinned host memory
+
+when slot S is needed for event N + pool_depth:
+  begin_retire_next()
+  -> verify every exposed result has a pending D2H token
+     or an independent CPU fallback
+  -> finish_retire_next() waits for D2H-done
+  -> release slot S
+  -> issue replacement H2D into slot S
+  -> yield event N as a host-backed context
+```
+
+If any result key lacks a host handoff, the controller conservatively keeps
+the yield-first two-phase retirement path and does not release the device slot
+before delivery.
+
+The replacement H2D is issued before the outgoing event is delivered to user
+CPU code. This permits work in another execution slot to overlap with that H2D.
+
+The normally retired context is explicitly marked `device_released`:
+
+- Result keys remain available through `ctx.get()`.
+- `on_cpu` consumes the pending pinned token or cached CPU result.
+- The context does not retain the old slot-backed CuPy array or its lease.
+- `on_gpu` and `on_gpu_view` raise a clear error.
+
+This prevents a host-backed event from exposing a stale GPU view after its
+device slot has been reused.
+
+At EndRun, BeginStep, end-of-input, or `max_events`, `EventPool.flush()` drains
+remaining records without scheduling a replacement H2D. It still preserves
+the consumer-registration and completion ordering before clearing each slot.
+
+### External GPU consumer: `gpu_d2h_chunk_size = 0`
+
+This mode preserves the slot-backed result while user code registers a GPU
+consumer:
+
+```text
+begin_retire_next()
+  -> synchronize producer
+  -> mark slot RETIRING but keep it occupied
+  -> yield slot-backed GPU result
+  -> user launches downstream kernel
+  -> on_gpu_view().__exit__ records and registers consumer-done event
+  -> finish_retire_next() waits for consumer-done
+  -> release slot
+  -> issue replacement H2D
+```
+
+The yield between `begin_retire_next()` and `finish_retire_next()` is the
+registration window. `submit()` rejects attempts to overwrite a slot while
+retirement is incomplete.
+
+External slot-backed results must be consumed during the current generator
+iteration, before requesting the next event. Retaining a slot-backed context
+and first accessing its GPU array after generator advancement is not safe.
+
+---
+
+## Why two-phase external retirement is required
+
+The old order inspected the leases and freed the slot before yielding the
+result:
+
+```text
+retire slot 0
+  -> no external consumer registered yet
+  -> free slot 0
+issue event 1 input
+yield event 0
+user launches delayed kernel for event 0 and registers completion too late
+event 1 calibration overwrites slot 0
+```
+
+The corrected order retains the slot while the user registers work:
+
+```text
+begin retirement of slot 0
+  -> keep slot 0 occupied
+yield event 0
+user launches kernel and registers consumer-done
+finish retirement
+  -> wait for consumer-done
+  -> free slot 0
+issue and submit event 1
+```
+
+`gpu_slot_overwrite_repro.py` exercises this race using `pool_depth=1`,
+`batch_size=1`, automatic D2H disabled, and a delayed external kernel. On the
+fixed implementation it should be run with `--expect safe`.
+
+---
+
+## `GPUResult` access modes
+
+### `on_cpu`
+
+`on_cpu` has three ordered paths:
 
 ```python
-for ctx in run.events():
-    arr  = ctx.get('jungfrau.calib').on_gpu    # ~2 ms D→D copy
-    hits = peak_finder(arr)
+if self._cpu_cache is not None:
+    return self._cpu_cache
+
+if self._pending_d2h is not None:
+    self._cpu_cache = self._pending_d2h.get()
+    self._pending_d2h = None
+    return self._cpu_cache
+
+if self._device_released or self._arr is None:
+    raise RuntimeError("host handoff is incomplete")
+
+self._cpu_cache = self._arr.get()
+return self._cpu_cache
 ```
 
-```
-slot_buf (VRAM, slot 0)
-    │
-    └─► arr.copy()  ──────────────────────────────────────────────────────►
-                      independent cp.ndarray in VRAM (not slot 0)
-                      slot 0 recycled immediately — no lease registered
-                      copy freed by Python GC after loop iteration
+The paths are:
+
+1. Return an independent cached CPU result.
+2. Consume the automatic pinned D2H token, copy to independent CPU memory,
+   cache it, and return it.
+3. With automatic D2H disabled, perform one blocking `arr.get()`, cache it,
+   and return it.
+
+Caching path 3 is required because a second D2H from the same slot-backed
+array could otherwise read a newer event after slot reuse.
+
+### `on_gpu`
+
+With automatic D2H disabled, `on_gpu` returns an independent D2D copy:
+
+```python
+arr = ctx.get("jungfrau.calib").on_gpu
 ```
 
-**SlotLease state after `on_gpu`:**
-```
-_d2h_done = None
-retire_next() → recycle immediately ✓
-```
+The copy should be requested during the current event iteration on the CuPy
+null/default stream. The next slot submission synchronizes that stream before
+overwriting the calibration output slot. For a custom consumer stream, use
+`on_gpu_view(stream)` so its completion event is registered explicitly.
 
-### `on_gpu_view(stream)` — zero-copy view
+In the normal automatic-D2H delivery path, device storage has already been
+released and `on_gpu` raises. Select `gpu_d2h_chunk_size=0` when the result is
+intended for GPU consumption.
 
-Returns a context manager.  `__enter__` yields a view directly into the
-slot buffer (fastest path, ~0 ms).  `__exit__` records a CUDA done-event
-on *stream* automatically — the slot is recycled only after that event fires.
-No user action beyond the `with` statement.
+### `on_gpu_view(stream)`
+
+This is the explicit zero-copy external-consumer API:
 
 ```python
 stream = cp.cuda.Stream(non_blocking=True)
 
 for ctx in run.events():
-    with ctx.get('jungfrau.calib').on_gpu_view(stream) as arr:
-        peak_finder(arr, stream=stream)     # must use the same stream
-    # done event recorded automatically in __exit__ — nothing else needed
+    with ctx.get("jungfrau.calib").on_gpu_view(stream) as arr:
+        downstream_kernel(arr, stream=stream)
 ```
 
-```
-slot_buf (VRAM, slot 0)
-    │
-    └─► view (same object)  ──────────────────────────────────────────────►
-                               user kernel reads directly from slot 0
-                               __exit__ records done_event on stream
+All kernels reading the view must be enqueued on the supplied stream inside
+the `with` block. `__exit__` records a done-event on that stream and registers
+it with the result lease.
 
-    retire_next(slot 0, 2 batches later):
-        wait_until_safe_to_reuse():
-            _d2h_done.synchronize()  ← blocks until kernel done ✓
-        stream.synchronize()
-        slot 0 recycled
-```
-
-**SlotLease state transitions:**
-```
-with on_gpu_view(stream):  (running user kernel)
-__exit__:                  _d2h_done = done_event  (recorded on stream)
-retire_next():             done_event.synchronize() → recycle ✓
-```
-
-**Key constraint:** all kernels that read the view must be enqueued on
-*stream* inside the `with` block.  A kernel on a different stream, or
-enqueued after `__exit__`, will not be captured by the done-event.
-
-### `on_cpu` — transparent D→H
-
-Returns a numpy array.  When `gpu_d2h_chunk_size > 0`, the D→H was already
-issued by `_D2hPipeline` before the context was yielded — `on_cpu` waits
-lazily only if the transfer hasn't completed yet.  `release_after` is called
-automatically by the pipeline.
-
-```python
-ds = DataSource(..., gpu_d2h_chunk_size=10)
-
-for ctx in run.events():
-    arr = ctx.get('jungfrau.calib').on_cpu     # numpy, D→H transparent
-    numpy_analysis(arr)
-```
-
-```
-Time →   0ms       10ms      20ms      30ms      40ms      50ms
-         │          │         │         │          │          │
-GPU:     [── calib events 0-9 on stream_0 ──────────────────►]
-                    │
-             calib_done ← CUDA event recorded
-
-_D2hPipeline._flush_chunk() at ~10ms:
-    stream.wait_event(calib_done)
-    memcpyAsync(pinned, slot_view) ─────────────────────────►[done ~50ms]
-    done_event.record()
-    for each event: result._pending_d2h = _PendingD2H(pslot, row, n_segs)
-    yield ctx immediately ← D→H still in-flight
-
-user calls on_cpu(ctx_0) at ~12ms:
-    _pending_d2h.get()
-        done_event.synchronize() ───────── blocks until ~50ms ────────────►
-        pslot.arr[0].copy()    ← ~0.1ms
-        return numpy array     ← at ~50ms
-
-user calls on_cpu(ctx_1..9):
-    done_event already fired → returns instantly
-```
-
-**SlotLease state:**
-```
-_D2hPipeline issues D→H:  registers done_event via lease.register_d2h_done()
-retire_next():             done_event.synchronize() → recycle ✓
-```
-
-### Comparison
-
-| Property | `on_gpu` | `on_gpu_view(stream)` | `on_cpu` |
-|---|---|---|---|
-| Returns | `cp.ndarray` copy | `cp.ndarray` view (via `with`) | `np.ndarray` |
-| VRAM cost | +38 MB (copy) | 0 | 0 |
-| Transfer | D→D ~2 ms | none | D→H ~13 ms or transparent |
-| Slot recycled | immediately | after `__exit__` done-event fires | after D→H done |
-| User action | none | use `with` block; kernel on same stream | none |
-| If forgotten | n/a | `__del__` records null-stream fallback | n/a |
+Automatic D2H and `on_gpu_view()` are intentionally mutually exclusive. Use
+`gpu_d2h_chunk_size=0` for this path.
 
 ---
 
-## How it works in the code
+## Pinned-host backpressure and fallback
 
-### 1. `_D2hPipeline._flush_chunk()` — issue and attach token
+Pinned buffers remain claimed until their result tokens are consumed or
+destroyed. If every pinned slot is retained, `_D2hPipeline.schedule()` does
+not defer an unsafe fallback to a future `on_cpu()` call.
 
-When `chunk_size` events have accumulated, the pipeline:
+Instead, while the device lease is still valid, it:
 
-1. Issues `cudaMemcpyAsync` from the slot output view to a pinned host
-   buffer (returns immediately, D→H runs on a separate CUDA stream).
-2. Creates a `_PendingD2H` token for each event that carries:
-   - a reference to the pinned slot (`_pslot`)
-   - which row in the slot belongs to this event (`_row`)
-   - the CUDA done-event (`_pslot.done_event`)
-3. Attaches the token to `GPUResult._pending_d2h`.
-4. **Yields the context immediately** — the transfer is still in-flight.
+1. Synchronizes the result-ready event.
+2. Calls blocking `arr.get()`.
+3. Stores the independent NumPy result in
+   `_EventSlot.cached_cpu_results_by_ts`.
+4. Allows the execution slot to retire safely.
 
-```
-                  ┌──────────────────────────────────────┐
-                  │  _D2hPipeline._flush_chunk()          │
-                  │                                        │
-  slot view ──►  memcpyAsync(pinned, view)  ← async      │
-                  done_event.record()                      │
-                  │                                        │
-                  │  for each event i:                     │
-                  │    result._pending_d2h =               │
-                  │      _PendingD2H(pslot, row=i, ...)   │
-                  │    yield ctx   ◄── immediately         │
-                  └──────────────────────────────────────┘
-```
+This keeps memory bounded and avoids both deadlock and delayed reads from a
+reused device slot. Automatic D2H resumes when a pinned slot returns to the
+free queue.
 
-### 2. `_PendingD2H.get()` — sync on demand
-
-The token is consumed the first time `on_cpu` is called:
-
-```python
-class _PendingD2H:
-    def get(self) -> np.ndarray:
-        self._pslot.done_event.synchronize()   # wait for D→H
-        data = self._pslot.arr[self._row, :self._n_segs].copy()
-        self._pslot.dec_ref()                  # release pinned slot ref
-        self._pslot = None                     # prevent __del__ double-release
-        return data
-```
-
-The `_pslot` reference keeps the pinned buffer alive until every event
-in the chunk has called `on_cpu`.  When the last event calls `dec_ref()`
-the slot's reference count reaches zero and it is returned to the
-`_available` queue for reuse.
-
-### 3. `SlotLease.wait_until_safe_to_reuse()` — two outcomes
-
-```python
-def wait_until_safe_to_reuse(self):
-    if self._d2h_done is not None:
-        # on_cpu path or on_gpu_view(stream) __exit__ — wait for consumer
-        self._d2h_done.synchronize()
-    # else: on_gpu (copy) or no access — recycle immediately
-```
-
-### 4. `GPUResult.on_cpu` — three-path property
-
-```python
-@property
-def on_cpu(self):
-    # Path 1: already cached from a previous call — free.
-    if self._pinned_cpu is not None:
-        return self._pinned_cpu
-
-    # Path 2: lazy sync — pipeline issued D→H before yielding.
-    if self._pending_d2h is not None:
-        self._pinned_cpu  = self._pending_d2h.get()   # waits here
-        self._pending_d2h = None
-        return self._pinned_cpu
-
-    # Path 3: fallback — no pipeline active (gpu_d2h_chunk_size=0).
-    return self._arr.get()
-```
+The pinned-slot reference counter is protected by a lock so concurrent
+`on_cpu()` calls cannot lose a decrement and permanently remove a slot from
+the free queue.
 
 ---
 
-## D→H pipeline walkthrough
+## Backpressure layers
 
-### 1. Object graph — what exists at steady state
+The implementation has three distinct bounds.
 
-```
-_D2hPipeline
-  _available ──► SimpleQueue ──► [ slot_0 │ slot_1 ]   (both free initially)
-  _pinned_pool ─► list ────────► [ slot_0 , slot_1 ]
-  _chunk_buf   ─► []
-  _d2h_stream  ─► cp.cuda.Stream (non_blocking=True)
+### 1. Execution-slot backpressure
 
-  _PinnedSlot (slot_0)                        _PinnedSlot (slot_1)
-  ┌──────────────────────────────────────┐    ┌─────────────────────────────┐
-  │ arr  [chunk_size × segs × rows × cols│    │ arr  [same shape]           │
-  │       page-locked host memory        │    │ page-locked host memory      │
-  │ done_event: cp.cuda.Event            │    │ done_event: cp.cuda.Event   │
-  │ _refs: 0                             │    │ _refs: 0                    │
-  │ _refs_lock: threading.Lock           │    │ _refs_lock: threading.Lock  │
-  │ _available ──► (pipeline's queue)    │    │ _available ──► (same queue) │
-  └──────────────────────────────────────┘    └─────────────────────────────┘
+`EventPool` has `n_gpu_streams` reusable slots. A requested slot cannot be
+reused until its producer and terminal-consumer events have completed.
+
+```text
+free execution slot exists -> admit work
+all required slots occupied -> CPU scheduler waits at retirement
+terminal consumer completes -> slot credit returns
 ```
 
-Both slots start in the queue.  A slot leaves the queue when a chunk is
-flushed (`get_nowait()`) and returns when all its events have called
-`on_cpu` (`put(self)` from `dec_ref()`).
+### 2. Pinned-host backpressure
+
+The automatic-D2H pinned pool is bounded by its slot count and chunk capacity.
+When it is exhausted, results are materialized synchronously into independent
+CPU memory rather than allocating without limit or exposing a stale device
+view.
+
+### 3. Device-memory backpressure
+
+`_GpuBudget` accounts for committed device allocations. One coherent EB batch
+is divided into byte-bounded `GpuSubbatchView` objects before submission.
+
+KvikIO raw input slots and calibrated output slots reserve committed bytes
+directly. Fixed constants and geometry are subtracted when deriving the
+per-subbatch allowance. Detector raw/gather scratch and input bytes are
+included in subbatch estimation, while the remaining CuPy allocator overhead
+is covered by the safety margin.
+
+Pinned host memory is tracked separately through `_D2hPipeline.pinned_bytes()`.
+
+These controls are related but not interchangeable: pool depth bounds active
+execution pipelines, D2H chunk size bounds each host-transfer buffer, and the
+GPU budget bounds committed VRAM bytes.
 
 ---
 
-### 2. Flushing one chunk (chunk_size = 3)
+## Pool-depth concurrency
 
+Within one execution slot, reuse follows a protected ownership chain:
+
+```text
+raw input -> parsed raw -> calibrated result -> terminal consumer -> release
 ```
-Step A — take a free slot
-─────────────────────────
-  _get_free_slot():
-    _available.get_nowait()  →  slot_0      queue = [slot_1]
 
-Step B — issue async D→H, then claim
-─────────────────────────────────────
-  stream.wait_event(lease.calib_done)              ← calibration must be done first
-  cudaMemcpyAsync(slot_0.arr[0], gpu_arr_0)  ─┐
-  cudaMemcpyAsync(slot_0.arr[1], gpu_arr_1)   ├── all on d2h_stream, returns ~0 ms
-  cudaMemcpyAsync(slot_0.arr[2], gpu_arr_2)  ─┘
-  slot_0.done_event.record(d2h_stream)
-  slot_0.claim(n=3)  →  _refs = 3
+For automatic D2H, D2H is the terminal device consumer. For external mode,
+the user-registered kernel is the terminal consumer.
 
-Step C — attach lazy-sync tokens and yield immediately
-───────────────────────────────────────────────────────
-  ctx_0._cache['jungfrau.calib']._pending_d2h = _PendingD2H(slot_0, row=0, n_segs)
-  ctx_1._cache['jungfrau.calib']._pending_d2h = _PendingD2H(slot_0, row=1, n_segs)
-  ctx_2._cache['jungfrau.calib']._pending_d2h = _PendingD2H(slot_0, row=2, n_segs)
-  return [ctx_0, ctx_1, ctx_2]     ← D→H is still in-flight here!
+With `pool_depth=1`, the same slot is required for every event, so the
+pipeline is effectively sequential:
 
-  slot_0 is now pinned by 3 _PendingD2H tokens via _refs = 3
-  Any of them can independently wait for done_event and copy their row.
+```text
+slot 0: H2D0 -> calib0 -> D2H0 -> release -> H2D1 -> calib1 -> ...
 ```
+
+With `pool_depth=2`, two protected pipelines can overlap:
+
+```text
+slot 0: H2D0 -> calib0 -> D2H0 -> release -> H2D2 -> ...
+slot 1: H2D1 -> calib1 -> D2H1 -> release -> H2D3 -> ...
+```
+
+For the normal automatic-D2H replacement path, the controller releases the
+outgoing slot and issues its replacement H2D before yielding the host-backed
+event. This permits, for example, H2D2 to overlap D2H1 when timing allows.
+
+In a ten-event Nsight Systems run with `batch_size=1`, `pool_depth=2`, and
+`gpu_d2h_chunk_size=2`, 8 of the 9 possible D2H-to-next-H2D pairs overlapped.
+This is a measured example, not a performance assertion in the unit tests.
 
 ---
 
-### 3. User calls `on_cpu` — lazy sync and slot release
+## KvikIO read ownership and early termination
 
-```
-ctx_0.get('jungfrau.calib').on_cpu
-│
-├── GPUResult.on_cpu  (path 2 — pending_d2h set)
-│     _pending_d2h.get():
-│       slot_0.done_event.synchronize()    ← may block here (~13 ms first call)
-│       data = slot_0.arr[0, :n_segs].copy()
-│       slot_0.dec_ref():
-│         with _refs_lock:  _refs 3 → 2  (freed = False)
-│       _pslot = None          ← prevents __del__ double-release
-│       return numpy array
-│     _pending_d2h = None,  _pinned_cpu = numpy array
+The controller permits at most one KvikIO `PendingBatch` to be pre-issued
+ahead of CPU event processing. Because automatic mode can issue replacement
+H2D before yielding a CPU event, the generator may be closed while that read
+is still in flight.
 
-ctx_1.get('jungfrau.calib').on_cpu
-│
-├── _pending_d2h.get():
-│     slot_0.done_event.synchronize()    ← already done, returns instantly
-│     data = slot_0.arr[1, :n_segs].copy()
-│     slot_0.dec_ref():  _refs 2 → 1  (freed = False)
+`GpuEvents` therefore:
 
-ctx_2.get('jungfrau.calib').on_cpu
-│
-└── _pending_d2h.get():
-      slot_0.done_event.synchronize()    ← already done, returns instantly
-      data = slot_0.arr[2, :n_segs].copy()
-      slot_0.dec_ref():
-        with _refs_lock:  _refs 1 → 0  (freed = True)
-      _available.put(slot_0)   ◄── slot returns to the free pool!
+- Stores the owned pending read in `_pending_gpu_read`.
+- Rejects a second pre-issued read while one is outstanding.
+- Clears ownership when `wait_batch()` completes.
+- Drains an outstanding read before `gpu_reader.close()` during shutdown.
 
-      queue is now [slot_0, slot_1] — both free again
-```
+This prevents reader buffers and file state from being closed underneath an
+in-flight H2D.
 
 ---
 
-### 4. Two-chunk timeline — how PCIe latency is hidden
+## Transition and drain behavior
 
-```
-Time →    0ms        13ms       20ms       33ms       40ms
-          │           │          │           │          │
+BeginStep drains dependent GPU work before calibration constants are replaced.
+EndRun, end-of-input, and `max_events` drain occupied slots exactly once.
 
-GPU stream_0:
-  [──── calib chunk 0 (events 0-9) ────]
-                      │  [──── calib chunk 1 (events 10-19) ────]
+`EventPool.flush()`:
 
-D→H stream:
-  [──── memcpyAsync into slot_0 ──────────────────────]
-                                  [──── memcpyAsync into slot_1 ──────────]
+1. Synchronizes the producer stream.
+2. Yields the record while retaining slot ownership.
+3. Allows a terminal consumer to register.
+4. Waits for registered consumer events in `finally`.
+5. Clears the slot.
 
-Generator:
-  flush chunk 0 → slot_0 from queue → issue D→H → yield ctx 0–9
-  flush chunk 1 → slot_1 from queue → issue D→H → yield ctx 10–19
-
-User:
-  ctx 0:  synchronize ──► blocks ~13 ms  │ copy | dec_ref (_refs=9)
-  ctx 1:  done already ──► instant       │ copy | dec_ref (_refs=8)
-  ...
-  ctx 9:  done already ──► instant       │ copy | dec_ref (_refs=0)
-                                                → put(slot_0) ─► queue=[slot_0]
-  ctx 10: synchronize ──► blocks ~33 ms  │ copy | dec_ref (_refs=9)
-  ...
-  ctx 19: done already ──► instant       │ copy | dec_ref (_refs=0)
-                                                → put(slot_1) ─► queue=[slot_0, slot_1]
-
-  ─────────────────────────────────────────────────────────────────────────
-  Only ctx_0 and ctx_10 block (the first call per chunk waits for D→H).
-  The other 18 calls return in ~0.1 ms each (done_event already fired).
-  The GPU calibrates chunk 1 while chunk 0 is transferring — no idle time.
-```
+The `finally` block also protects generator close and exceptions during result
+delivery.
 
 ---
 
-### 5. Sync fallback when the queue is empty
+## Usage rules
 
-Triggered when the user accumulates contexts without calling `on_cpu` fast
-enough.  The generator yields without `_pending_d2h`; `on_cpu` falls back to
-a synchronous `_arr.get()`.  Async D→H resumes automatically once any slot
-is returned to the queue.
-
-```
-_available queue is empty (both slots claimed, on_cpu not yet called)
-
-  Generator                          User
-  ─────────                          ──────────────────────────────────
-  add(ctx_20):
-    _get_free_slot():
-      _available.get_nowait()
-      → raises Empty  →  return None
-
-    _flush_chunk(pslot=None):
-      return [ctx_20]    ← no _pending_d2h attached
-
-  yield ctx_20 immediately
-
-                                     ctx_20.get('jungfrau.calib').on_cpu:
-                                       _pending_d2h is None  ← skip lazy path
-                                       _stream.synchronize()
-                                       return _arr.get()     ← sync D→H here
-
-                                     ctx_18.get(...).on_cpu  →  dec_ref → _refs=0
-                                       → _available.put(slot_0)
-                                          ↑ queue non-empty again ✓
-
-  add(ctx_21):
-    _get_free_slot():
-      _available.get_nowait()  →  slot_0   ← async D→H resumes
-```
-
----
-
-### 6. `_refs_lock` prevents the lost-update race
-
-Without the lock, two concurrent `on_cpu` calls (one per event in the same
-chunk) can both read the same stale `_refs` value, both decrement it to the
-same result, and both store that value — so the count never reaches zero and
-the slot is never returned to the queue.
-
-```
-slot_0._refs = 2  (chunk_size=2, two _PendingD2H tokens outstanding)
-
-  WITHOUT lock:
-  Thread A (on_cpu ctx_0)      Thread B (on_cpu ctx_1)
-  ────────────────────────     ─────────────────────────
-  LOAD  _refs  → 2             LOAD  _refs  → 2   ← reads stale 2
-  [GIL switches to B]
-                               SUBTRACT  → 1
-                               STORE _refs = 1
-  SUBTRACT  → 1
-  STORE _refs = 1              ← overwrites B's store!
-  1 > 0 → no put()             1 > 0 → no put()
-  slot_0 NEVER RETURNED TO QUEUE  ✗
-
-  WITH _refs_lock:
-  Thread A                     Thread B
-  ────────────────────────     ─────────────────────────
-  acquire _refs_lock
-  LOAD 2, SUBTRACT → 1
-  STORE _refs = 1
-  freed = False
-  release _refs_lock
-                               acquire _refs_lock
-                               LOAD 1, SUBTRACT → 0
-                               STORE _refs = 0
-                               freed = True
-                               release _refs_lock
-                               _available.put(slot_0)  ✓
-```
-
----
-
-## What happens if the user never calls on_gpu, on_gpu_view, or on_cpu
-
-### Path 1 — no access at all
-
-```python
-for ctx in run.events():
-    pass
-```
-
-`lease._d2h_done` stays `None`.
-`retire_next()` recycles the slot immediately.  **No problem.**
-
-### Path 2 — `on_gpu` accessed, result discarded
-
-```python
-for ctx in run.events():
-    arr = ctx.get('jungfrau.calib').on_gpu     # copy made
-    # arr goes out of scope at next iteration
-```
-
-The copy is GC'd when `arr` goes out of scope.  The slot was never
-locked — it was recycled immediately after the copy.  **No problem.**
-
-### Path 3 — `on_gpu_view` context manager used correctly
-
-```python
-stream = cp.cuda.Stream(non_blocking=True)
-for ctx in run.events():
-    with ctx.get('jungfrau.calib').on_gpu_view(stream) as arr:
-        kernel(arr, stream=stream)
-    # __exit__ sets lease._d2h_done = done_event
-```
-
-`lease._d2h_done` is set by `_GpuViewContext.__exit__` before the `with` block exits.
-`retire_next()` synchronizes the done-event.  **Correct.**
-
-If the user forgets the `with` and the `_GpuViewContext` object is
-garbage-collected, `__del__` records a conservative done-event on the null
-stream — the slot is never permanently held.
-
-### Path 4 — D→H pipeline, `on_cpu` never called
-
-```python
-ds = DataSource(..., gpu_d2h_chunk_size=10)
-for ctx in run.events():
-    pass   # _pending_d2h set but on_cpu never called
-```
-
-`_PendingD2H.__del__()` calls `pslot.dec_ref()` when the context is GC'd.
-The slot's D→H completes and it is freed.  Correct but **wasted PCIe bandwidth**.
-
-### Safe usage rules
-
-| Pattern | Safe? |
+| Configuration and access | Safe use |
 |---|---|
-| `on_gpu` in same iteration | Yes — copy is independent |
-| `with on_gpu_view(stream) as arr:` in same iteration | Yes — done-event auto-recorded |
-| `on_gpu_view(stream)` object received but `with` not used | Handled by `__del__` (null-stream fallback) |
-| `on_cpu` in same iteration | Yes |
-| Ignore all results | Yes — GC handles cleanup |
-| Collect all contexts, call `on_cpu` later | Unsafe if `n_events > max_inflight × chunk_size` |
+| Automatic D2H plus `on_cpu` | Supported; contexts may retain their host token or cached CPU result |
+| Automatic D2H plus `on_gpu_view` | Unsupported; use `gpu_d2h_chunk_size=0` |
+| External mode plus `on_gpu` | Request the independent copy on the null/default stream during the current iteration |
+| External mode plus `on_gpu_view(stream)` | Enqueue all readers on `stream` inside the `with` block during the current iteration |
+| External mode plus `on_cpu` | First call blocks and caches; call before advancing if the result is still slot-backed |
+| Retain an unconsumed external slot-backed context | Unsafe; its slot may be reused after generator advancement |
+| Ignore automatic-D2H results | Safe; token destruction releases pinned references, but the D2H bandwidth is wasted |
+
+Do not infer safety from Python object lifetime alone. A slot-backed GPU view
+must have an explicit CUDA completion event registered before the generator
+advances.
 
 ---
 
-## Batch-boundary flush
+## Validation
 
-If `batch_size % chunk_size != 0` some events are left in `_chunk_buf`
-at the end of a batch.  `_yield_ready()` calls `_flush_d2h_pipelines()`
-after every batch so no event is stranded:
+The GPU unit tests cover:
 
+- A slot cannot be submitted before retirement finishes.
+- A consumer registered after `begin_retire_next()` is observed by
+  `finish_retire_next()`.
+- Generator advancement alone does not complete a lease.
+- The D2H stream waits for the result-ready event.
+- Complete and partial execution-slot records receive D2H tokens immediately.
+- `on_cpu()` returns correct data and caches synchronous fallback results.
+- Pinned exhaustion materializes a safe CPU fallback before device reuse.
+- Concurrent pinned-slot reference decrements return the slot exactly once.
+- `on_gpu()` returns an independent copy.
+- `on_gpu_view()` records the supplied stream's completion event.
+- Byte-bounded subbatch and `_GpuBudget` invariants.
+
+The overwrite diagnostic is:
+
+```bash
+mpirun -n 3 \
+  python -u psana/psana/debugtools/gpu_slot_overwrite_repro.py \
+    --exp mfx100848724 \
+    --run 51 \
+    --dir /sdf/data/lcls/ds/prj/public01/xtc \
+    --expect safe \
+    --log-level WARNING
 ```
-batch_size=15, chunk_size=10
 
-  events 0-9  → chunk full → D→H issued → yield immediately
-  events 10-14 → partial chunk (5 events)
-  end of batch → _flush_d2h_pipelines()
-                   └─ pipe.flush() → D→H issued for 5 events → yield
-```
+The timeline driver is `psana/psana/debugtools/ds_count_events.py`. With
+`--gpu_d2h_interval 1`, it calls `on_cpu()` for every event so automatic D2H
+and its CPU delivery are visible in Nsight Systems.
 
 ---
 
-## Pool depth = 2
+## Current source map
 
-Pool_depth=2 fully hides the calibration kernel behind I/O.
-Pool_depth=4 adds no parallelism (one NVMe read in-flight at a time)
-and doubles the slot-buffer VRAM cost.
-
-```
-pd=2 (Jungfrau, bs=20):  2 × 760 MB = 1.5 GB   (sufficient)
-pd=4:                     4 × 760 MB = 3.0 GB   (2× waste, was prior default)
-```
-
----
-
-## Memory budget — `_GpuBudget`
-
-`_GpuBudget` is a simple committed-bytes counter that guards every
-`cp.empty()` call in the pipeline.  Its single job is OOM prevention:
-raise a human-readable error before the allocation happens, rather than
-letting the CUDA driver crash the MPI job with a cryptic broken-pipe
-message.  Correctness (slot ownership, safe recycling) is handled
-separately by `SlotLease.wait_until_safe_to_reuse()`.
-
----
-
-### 1. Ownership and sharing
-
-One `_GpuBudget` instance is created by `GpuEvents._setup_detectors()`
-and passed by reference to every component that allocates VRAM.  All
-allocations therefore count against the same per-BD limit.
-
-```
-GpuEvents._setup_detectors()
-  │
-  ├── _GpuBudget(limit = device_total / n_bd_ranks)   ◄── single instance
-  │        │
-  │        ├─── → KvikioGpuReader(_budget=budget)     raw input slot buffers
-  │        └─── → GPUDetector(_budget=budget)          calib output slot buffers
-  │                   (one GPUDetector per det_name)
-  │
-  └── _compute_subbatch_budget()
-           reads budget.limit() and budget.committed()
-           → _subbatch_budget_bytes (drives _split_subbatches)
-```
-
-Default limit: `device_total / n_bd_ranks` auto-detected from CuPy at
-BeginRun.  Override: `DataSource(gpu_memory_budget_gb=15)`.
-
----
-
-### 2. VRAM layout — what is tracked vs. not tracked
-
-```
-VRAM  (example: A100 80 GiB, 2 BD ranks → limit = 40 GiB)
-╔══════════════════════════════════════════════════════════════════╗
-║  FIXED  —  allocated at BeginRun, never freed                   ║
-║  counted in budget._committed from the moment they are reserved ║
-║                                                                  ║
-║  ┌──────────────────────────┐  ┌──────────────────────────┐    ║
-║  │  peds_gpu + gmask_gpu    │  │  scatter_ix + scatter_iy │    ║
-║  │  calibration constants   │  │  geometry scatter maps   │    ║
-║  │  float32 + float32       │  │  int64 + int64           │    ║
-║  │  ≈ 1.2 GiB  (19-seg JF) │  │  ≈ 0.3 GiB  (19-seg JF) │    ║
-║  └──────────────────────────┘  └──────────────────────────┘    ║
-║                                                                  ║
-║  VARIABLE  —  one buffer per EventPool slot, grown lazily       ║
-║  reserve() / release() called on every resize                   ║
-║                                                                  ║
-║  ┌────────────────────────────────────────────────────────┐    ║
-║  │  slot 0                        slot 1                  │    ║
-║  │  ┌─────────────────────┐       ┌─────────────────────┐│    ║
-║  │  │ calib_slot_bufs[0]  │       │ calib_slot_bufs[1]  ││    ║
-║  │  │ GPUDetector         │       │ GPUDetector         ││    ║
-║  │  │ float32             │       │ float32             ││    ║
-║  │  │ (events×segs×r×c)   │       │ (events×segs×r×c)   ││    ║
-║  │  ├─────────────────────┤       ├─────────────────────┤│    ║
-║  │  │ _slot_bufs[0]       │       │ _slot_bufs[1]       ││    ║
-║  │  │ KvikioGpuReader     │       │ KvikioGpuReader     ││    ║
-║  │  │ uint8 raw input     │       │ uint8 raw input     ││    ║
-║  │  └─────────────────────┘       └─────────────────────┘│    ║
-║  └────────────────────────────────────────────────────────┘    ║
-║                                                                  ║
-║  NOT TRACKED  —  covered by the 10% margin                      ║
-║  ┌────────────────────────────────────────────────────────┐    ║
-║  │  CuPy allocator pool   _raw_slot_bufs (uint16 scratch) │    ║
-║  └────────────────────────────────────────────────────────┘    ║
-║                                                                  ║
-║  ──────────────────────────────────────────────────────         ║
-║  budget.committed ≈ fixed + Σ calib_slot_bufs + Σ _slot_bufs   ║
-║  budget.limit     = device_total / n_bd_ranks   (40 GiB here)  ║
-╚══════════════════════════════════════════════════════════════════╝
-
-PINNED HOST MEMORY  (separate, not counted in _GpuBudget)
-┌────────────────────────────────────────────────────────────────┐
-│  _D2hPipeline._PinnedSlot[0]   _PinnedSlot[1]                  │
-│  page-locked, float32, (chunk_size × segs × r × c)             │
-│  tracked separately by _D2hPipeline.pinned_bytes()             │
-└────────────────────────────────────────────────────────────────┘
-```
-
----
-
-### 3. The reserve / release cycle
-
-Both variable buffer owners follow the same pattern: `release` the old
-size, `reserve` the new size, then call `cp.empty`.  This keeps
-`_committed` accurate on both grow and shrink.
-
-```
-                    issue_batch(subbatch, slot=0)
-                             │
-     KvikioGpuReader         │          GPUDetector
-     ─────────────────       │          ──────────────────────────
-     old = _slot_bufs[0]     │          old = _calib_slot_bufs[0]
-           .nbytes            │                .nbytes
-              │               │                │
-     budget.release(old) ◄───┤──────► budget.release(old)
-     budget.reserve(new) ───►│◄────── budget.reserve(needed)
-          raises if OOM  ────┤──────── raises if OOM
-              │               │                │
-     cp.empty(new, uint8) ──►│◄── cp.empty(batch_shape, float32)
-     _slot_bufs[0] = buf      │    _calib_slot_bufs[0] = buf
-                              │
-                     [slot 0 in-flight]
-
-                    issue_batch(subbatch+1, slot=1)
-                             │
-                    same pattern for slot 1 ──► slot 1 in-flight
-
-                    issue_batch(subbatch+2, slot=0 recycled)
-                             │
-                    usually same size → release + reserve = no-op
-                    only re-allocates if batch_size changed
-```
-
----
-
-### 4. `reserve()` — OOM prevention flow
-
-```
-budget.reserve(n)
-        │
-        ▼
-committed + n <= limit?
-        │
-   YES ─┤─► committed += n   (fast path, ~always taken)
-        │
-   NO ──┤
-        ▼
-cp.get_default_memory_pool().free_all_blocks()
-   (flush CuPy's cached-but-unused allocations)
-        │
-        ▼
-committed + n <= limit?
-        │
-   YES ─┤─► committed += n   (pool flush recovered enough room)
-        │
-   NO ──┤
-        ▼
-raise GpuMemoryPressureError(
-    "need X GiB, committed Y GiB, limit Z GiB.\n"
-    "Reduce batch_size or n_gpu_streams, or increase gpu_memory_budget_gb."
-)
-```
-
-The two-step check matters: CuPy keeps freed arrays in a pool to amortise
-`cudaMalloc` latency.  A large batch may appear to exceed the limit while
-several GiB of pool blocks sit unused.  The flush reclaims them before
-giving up.
-
----
-
-### 5. Subbatch budget — how the limit drives splitting
-
-`_compute_subbatch_budget()` derives the per-subbatch VRAM cap from the
-same `_GpuBudget` limit, reserving headroom for fixed allocations and
-CuPy pool overhead:
-
-```
-_compute_subbatch_budget()
-  │
-  ├── limit       = _gpu_budget.limit()            (e.g. 40 GiB)
-  ├── fixed_bytes = Σ det.memory_bytes()['constants']
-  │                + Σ det.memory_bytes()['geometry']  (e.g. 1.5 GiB)
-  ├── margin      = limit × 10%                    (e.g. 4.0 GiB)
-  ├── variable    = limit − fixed_bytes − margin   (e.g. 34.5 GiB)
-  ├── n_slots     = EventPool depth                (e.g. 2)
-  │
-  └── per_subbatch = max(variable / n_slots, 256 MiB)
-                   = max(17.25 GiB, 256 MiB)
-                   = 17.25 GiB  ◄── _subbatch_budget_bytes
-```
-
-`_split_subbatches()` uses this cap in a greedy bin-pack loop:
-
-```
-for each event e in EB batch:
-    e_bytes = GPUDetector.estimate_subbatch_bytes(1)
-            = n_segs × nrows × ncols × (4 + 2)   [float32 + uint16]
-
-    if current_bytes + e_bytes > _subbatch_budget_bytes
-       AND current subbatch already has ≥ 1 event:
-        ── flush current subbatch ──► EventPool slot k
-        ── start new subbatch
-
-    append e to current subbatch
-    current_bytes += e_bytes
-```
-
-This guarantees that no subbatch requests more VRAM than the budget
-allows — the calib slot buffer grows to fit the subbatch and `reserve()`
-will succeed.
-
----
-
-### 6. Budget numbers for MFX Jungfrau (19 segments, A100 80 GiB)
-
-```
-Component                     Size         Tracked?
-──────────────────────────     ──────────   ────────
-peds_gpu  (float32 flat)       ~0.6 GiB    yes — fixed
-gmask_gpu (float32 flat)       ~0.6 GiB    yes — fixed
-scatter_ix + iy (int64)        ~0.3 GiB    yes — fixed
-calib_slot_bufs[0] (float32)   ~0.2 GiB*   yes — variable
-calib_slot_bufs[1] (float32)   ~0.2 GiB*   yes — variable
-_slot_bufs[0] (uint8)          ~0.1 GiB*   yes — variable
-_slot_bufs[1] (uint8)          ~0.1 GiB*   yes — variable
-_raw_slot_bufs (uint16)        ~0.1 GiB    no  — in margin
-CuPy allocator pool            varies      no  — in margin
-_PinnedSlot[0,1] (host)        ~0.1 GiB    no  — host memory
-
-budget.committed (steady state)   ≈ 2.1 GiB  (<<  40 GiB limit)
-_subbatch_budget_bytes            ≈ 17.2 GiB (per subbatch)
-
-* grows with batch_size; shown for bs=20, 19-seg Jungfrau
-```
-
----
-
-## How subbatches, on_gpu_view, and backpressure fit together
-
-All three mechanisms revolve around a single concept: the **VRAM slot**.
-EventPool has 2 slots.  Every subbatch fills one slot, the user reads from
-it, and `retire_next()` waits until the slot is safe to overwrite.
-
----
-
-### The slot lifecycle
-
-```
-STEP 1 — SUBBATCH: decide what fits in the slot
-────────────────────────────────────────────────
-
-  EB batch: 500 events × 60 MB = 30 GB  >  17 GB per-slot budget
-                │
-                ▼
-  _split_subbatches()
-    subbatch 0 = events   0–289  (17 GB ≤ budget → fits in slot 0)
-    subbatch 1 = events 290–499  (12 GB ≤ budget → fits in slot 1)
-                │
-                ▼
-  submit(subbatch 0, slot=0):
-    GDS reads raw data    ───────────────────────► slot 0 raw buffer  │
-    GPU calibration kernel ──────────────────────► slot 0 calib buf   │ SLOT 0
-    calib_done.record()                                                │ IS FULL
-
-
-STEP 2 — USER: decide how long the slot is held
-────────────────────────────────────────────────
-
-  generator yields events; user calls one of:
-
-  ┌─────────────────────────────────────────────────────────┐
-  │  on_gpu (D→D copy)                                      │
-  │                                                         │
-  │  arr = ctx.get('jungfrau.calib').on_gpu                 │
-  │                                                         │
-  │  slot 0 ──► copy ──► independent arr (not in slot 0)   │
-  │  slot 0 FREE immediately                                │
-  │  lease._d2h_done = None                                 │
-  └─────────────────────────────────────────────────────────┘
-
-  ┌─────────────────────────────────────────────────────────┐
-  │  on_gpu_view (zero-copy)                                │
-  │                                                         │
-  │  with ctx.get('jungfrau.calib').on_gpu_view(s) as arr:  │
-  │      my_kernel(arr, stream=s)  ← reads slot 0 directly  │
-  │  # __exit__: done = Event(); s.record(done)             │
-  │               lease._d2h_done = done                    │
-  │                                                         │
-  │  slot 0 HELD until my_kernel finishes on GPU            │
-  └─────────────────────────────────────────────────────────┘
-
-  ┌─────────────────────────────────────────────────────────┐
-  │  on_cpu (D→H transfer)                                  │
-  │                                                         │
-  │  arr = ctx.get('jungfrau.calib').on_cpu                 │
-  │                                                         │
-  │  _D2hPipeline: cudaMemcpyAsync(slot 0 → pinned host)    │
-  │  pslot.done_event recorded after memcpy                 │
-  │  lease._d2h_done = pslot.done_event                     │
-  │                                                         │
-  │  slot 0 HELD until D→H transfer finishes (~13 ms)       │
-  └─────────────────────────────────────────────────────────┘
-
-
-STEP 3 — retire_next: enforce the slot is safe to overwrite
-────────────────────────────────────────────────────────────
-
-  Before slot 0 can hold the NEXT subbatch, retire_next() runs:
-
-  retire_next(slot 0):
-    lease._d2h_done.synchronize()   ← BLOCKS until event fires
-    old_stream.synchronize()        ← BLOCKS until calib kernel done
-    slot 0 = None  (recycled, safe to write)
-
-  on_gpu:       _d2h_done = None  →  no wait, instant recycle
-  on_gpu_view:  _d2h_done fires when user's kernel finishes
-  on_cpu:       _d2h_done fires when D→H to pinned host finishes
-```
-
----
-
-### Full cycle for one EB batch
-
-```
-  EB batch (500 events)
-        │
-        ▼  _split_subbatches()
-  ┌──────────────┐   ┌──────────────┐
-  │ subbatch 0   │   │ subbatch 1   │
-  │ events 0–289 │   │ events 290+  │
-  └──────┬───────┘   └──────┬───────┘
-         │                  │
-         ▼                  ▼
-    slot 0 fills        slot 1 fills    ← two slots overlap (double-buffered)
-         │                  │
-         ▼                  ▼
-    yield events        yield events
-    user: on_gpu/       user: on_gpu/
-    on_gpu_view/        on_gpu_view/
-    on_cpu              on_cpu
-         │                  │
-         │  lease._d2h_done set (or None)
-         │                  │
-         ▼                  ▼
-    retire_next()       retire_next()
-    BLOCKS until        BLOCKS until    ← BACKPRESSURE: generator stalls
-    slot 0 safe         slot 1 safe       here; _next_batch() not called
-         │                  │              EB rate-limited until both
-         ▼                  ▼              slots are recycled
-    slot 0 recycled     slot 1 recycled
-         │
-         ▼
-  next EB batch → _split_subbatches() again …
-```
-
----
-
-### Role of each mechanism
-
-| Mechanism | Question it answers | When |
-|---|---|---|
-| **Subbatch** | "how many events fit in one slot's VRAM?" | before GPU work starts |
-| **`on_gpu_view`** | "how long does the user hold the slot?" | while slot is full |
-| **`retire_next()`** | "is the slot safe to overwrite yet?" | before slot is reused |
-
-Subbatches control the **fill**.
-`on_gpu_view` controls the **hold**.
-`retire_next()` enforces the **release** — and because the generator blocks
-inside it, a slow user or slow D→H naturally rate-limits the EB rank.
-
----
-
-## DataSource parameters
-
-```python
-DataSource(
-    gpu_det              = 'jungfrau',
-    n_gpu_streams        = 2,     # pool depth — default 2 (was 4)
-    gpu_d2h_chunk_size   = 10,    # transparent on_cpu D→H — default 0 (disabled)
-    gpu_memory_budget_gb = 15,    # per-BD VRAM limit — default auto
-)
-```
-
----
-
-## Performance results (sdfampere, CPU-fallback I/O, 1000 events, 2 BD ranks, pd=2)
-
-### Run 3 — sdfampere035, 2026-07-27, job 33347452 (on_gpu_view + arr.sum baseline)
-
-```
-Configuration                        kHz        hot_ms
-────────────────────────────────     ─────────  ───────
-on_gpu_view baseline  bs= 1  pd=2    0.073 kHz  0.096 ms  ← view + arr.sum
-on_gpu_view baseline  bs=10  pd=2    0.057 kHz  0.054 ms
-on_gpu_view baseline  bs=20  pd=2    0.080 kHz   —
-_D2hPipeline  chunk= 1  bs=20        0.075 kHz   —        ← D→H hidden (same as baseline!)
-_D2hPipeline  chunk=10  bs=20        —                    ← preempted
-
-LCLS-II beam rate: 0.120 kHz
-```
-
-**Key result:** `bs=20 baseline = 0.080 kHz` and `D2H chunk=1 = 0.075 kHz` —
-effectively the same.  The lazy-sync design is confirmed: calling `on_cpu`
-(with D→H in the background) does not reduce aggregate throughput vs calling
-`on_gpu_view` (no D→H at all).
-
-**hot_ms** for the `on_gpu_view + arr.sum` path is 0.054–0.096 ms, slightly
-higher than the old `on_gpu` D→D copy path (0.028–0.056 ms) because
-`arr.sum()` reads the entire 19-segment array on the GPU before returning.
-This is a more realistic "user kernel" than a D→D copy.
-
-### Run 2 — sdfampere036, 2026-07-27, job 33331881 (on_gpu baseline)
-
-```
-Configuration                        kHz        hot_ms
-────────────────────────────────     ─────────  ───────
-GPU on_gpu baseline  bs= 1  pd=2     0.071 kHz  0.053 ms
-GPU on_gpu baseline  bs=10  pd=2     0.054 kHz  0.039 ms
-GPU on_gpu baseline  bs=20  pd=2     0.086 kHz  0.042 ms  ← IO-bottlenecked ceiling
-_D2hPipeline  chunk= 1  bs=20        0.086 kHz  19.9 ms  ← D→H hidden (same as baseline!)
-_D2hPipeline  chunk=10  bs=20        0.075 kHz  23.0 ms
-
-LCLS-II beam rate: 0.120 kHz
-```
-
-### Run 1 — earlier baseline (pre-simplification)
-
-```
-Configuration                        kHz        hot_ms
-────────────────────────────────     ─────────  ───────
-GPU baseline  bs= 1  pd=2            0.236 kHz  0.056 ms
-GPU baseline  bs=10  pd=2            0.264 kHz  0.031 ms  ← ceiling (no D→H)
-GPU baseline  bs=20  pd=2            0.276 kHz  0.028 ms
-_D2hPipeline  chunk= 1  bs=20        0.114 kHz  14.6 ms   ← D→H cost per event
-_D2hPipeline  chunk=10  bs=20        0.126 kHz  13.6 ms   ← lazy sync working
-
-LCLS-II beam rate: 0.120 kHz  ← GPU baseline at bs≥10 exceeds beam rate
-```
-
-The higher kHz values in Run 1 reflect lighter Lustre load on that day —
-the hot_ms values (0.028–0.056 ms) are the stable per-event GPU time.
-Both runs confirm the same qualitative result: D2H overhead is hidden.
-
-I/O path for both runs: CPU-fallback (Lustre → CPU DRAM → GPU VRAM via
-cudaMemcpy).  True GDS (NVMe → GPU direct) would eliminate the CPU-DRAM
-hop and raise the ceiling further.
-
----
-
-## Files changed
-
-| File | Change |
+| File | Responsibility |
 |---|---|
-| `context.py` | `on_gpu` → D→D copy; `on_gpu_view(stream)` → returns `_GpuViewContext`; `_GpuViewContext.__exit__` records done-event automatically; `SlotLease._needs_release` + `mark_needs_release()` + `RuntimeError` branch removed; `GPUResult.release_after()` removed |
-| `gpu_budget.py` | New — `_GpuBudget` + `GpuMemoryPressureError` |
-| `gpu_calib.py` | `GPUDetector.__init__` accepts `budget=`, `n_slots=2` default; `cp.empty()` guarded by `budget.reserve()` |
-| `gpu_kvikio_read.py` | Same — `budget=`, `n_slots=2`, `cp.empty()` guarded |
-| `gpu_events.py` | Creates `_GpuBudget.auto()` at init; `_D2hPipeline` gains `_available: SimpleQueue`; `_PinnedSlot` gains `available` + `_refs_lock` params; `dec_ref()` calls `_available.put(self)` when freed; `_get_free_slot()` calls `get_nowait()`, returns `None` when empty; `_flush_chunk()` yields events without `_pending_d2h` when slot unavailable |
-| `ds_base.py` | `n_gpu_streams` default 4→2; `gpu_memory_budget_gb` and `gpu_d2h_chunk_size` params added and forwarded to `DsParms` |
-| `tests/gpu/unit/test_event_joiner.py` | `test_get_free_slot_returns_none_when_all_slots_busy` + `test_dec_ref_race_lock_prevents_lost_update` |
+| `gpu_events.py` | Event controller, automatic D2H, host tokens, retirement policy, KvikIO pending-read ownership |
+| `gpu_stream.py` | `_EventSlot`, `EventPool`, slot leases, two-phase retirement |
+| `context.py` | `GPUResult`, `on_cpu`, `on_gpu`, `on_gpu_view`, host-only result state |
+| `gpu_kvikio_read.py` | Reusable per-slot raw input buffers and asynchronous reads |
+| `gpu_calib.py` | Per-slot calibration/raw buffers and result-ready producer work |
+| `gpu_budget.py` | Committed device-memory accounting |
+| `gpu_batch.py` | GPU batch and byte-bounded subbatch views |
 
 ---
 
-## Deferred
+## Deferred work
 
-| Feature | When |
-|---|---|
-| Shared-GPU coordination across BD ranks | Phase 4 |
-| True GDS (NVMe → GPU direct) | Infrastructure — Lustre/GPFS doesn't support cuFile |
-
----
-
-## Implementation phase status
-
-### Phase 0 — Measurement and accounting
-**Done.**
-- `GPUDetector.memory_bytes()` — constants, geometry, calib_slots, raw_slots
-- `KvikioGpuReader.memory_bytes()` — raw_input slots
-- `_D2hPipeline.pinned_bytes()` — pinned host memory
-- `_GpuMemStats` dataclass + `GpuEvents.log_memory()` — snapshot + high-water marks
-- Called automatically at setup, first batch, and EndRun
-
-### Phase 1 — Correct slot ownership
-**Done.**
-- `SlotLease` carries `calib_done` CUDA event and `_d2h_done` token
-- `EventPool.submit()` records `calib_done` and creates one lease per event
-- `EventPool.retire_next()` calls `wait_until_safe_to_reuse()` — generator
-  advancement alone no longer recycles a slot
-- `_PendingD2H.get()` calls `dec_ref()` to signal the slot is safe to reuse
-
-### Phase 2 — Bounded asynchronous D→H
-**Done.**
-
-| Requirement | Status |
-|---|---|
-| Direct async D→H from slot view to pinned chunk | Done — `_D2hPipeline._flush_chunk()` |
-| Separate logical join_size from physical chunk bytes | Done — `gpu_d2h_chunk_size` |
-| Partial-tail flush at EndRun / BeginStep | Done |
-| Partial-tail flush at batch boundary | Done |
-| No full-size D2D join buffer | Done |
-| Lazy sync — D→H overlaps with user processing | Done — `_pending_d2h` / `on_cpu` |
-| `on_gpu` safe by default (D→D copy) | Done |
-| `on_gpu_view(stream)` context manager — auto-records done-event | Done |
-| `_GpuBudget` simple committed-bytes counter | Done |
-| Pool depth default 2 | Done |
-| `gpu_memory_budget_gb` enforcement | Done |
-
-### Phase 3 — Byte-bounded subbatches + D→H backpressure
-**Done.**
-
-| Requirement | Status |
-|---|---|
-| Memory estimation in `GPUDetector` | Done — `estimate_subbatch_bytes(n_events)` |
-| Partitioning one EB batch into byte-bounded GPU subbatches | Done — `GpuEvents._split_subbatches()` + `GpuSubbatchView` |
-| Backpressure: no unconditional EB batch requests when queue full | Done — pending queue implicit in sequential subbatch processing |
-| `_compute_subbatch_budget()` auto-sizes from `_GpuBudget` | Done |
-
-
-Key design decisions:
-- `GpuSubbatchView` re-indexes `first_desc` to be relative to the subbatch's
-  own `desc_table` (built by `KvikioGpuReader._build_desc_table()`), not the
-  original batch's desc table.
-- Each subbatch is matched to its CPU events by timestamp lookup, so each
-  CPU event is yielded exactly once.
-- First subbatch reads are issued before the CPU EventManager loop to preserve
-  GDS/PCIe overlap with CPU SMD deserialization.
-- A single oversized event (exceeding budget alone) is never split — the rule
-  "at least one event per subbatch" prevents zero-event subbatches.
-- `_compute_subbatch_budget()` formula: `(limit − fixed_bytes − 10% margin) / n_slots`.
-
-#### D→H backpressure mechanism
-
-When all `_max_inflight=2` pinned slots are occupied, `_flush_chunk()` falls
-back to synchronous D→H so the generator never deadlocks.  Free-slot
-tracking, counting, and retrieval are combined into a single
-`queue.SimpleQueue`:
-
-```
-_D2hPipeline
-    _available = SimpleQueue()   ← holds free _PinnedSlot objects
-
-_PinnedSlot.dec_ref()
-    with _refs_lock:             ← atomic decrement (fixes _refs race)
-        _refs -= 1
-        freed = (_refs <= 0)
-        if freed: _refs = 0
-    if freed:
-        _available.put(self)     ← slot returns itself to the free pool
-
-_D2hPipeline._get_free_slot()
-    try:
-        return _available.get_nowait()   ← O(1), thread-safe, no scan
-    except Empty:
-        return None              ← all slots busy → sync D→H fallback
-```
-
-
-## Validation test coverage
-
-| Test requirement | Status |
-|---|---|
-| Slot cannot be recycled while D→H in flight | Done — `test_retire_next_waits_for_d2h_before_recycle` |
-| Generator advancement alone does not release a lease | Done — `test_generator_advancement_alone_does_not_release` |
-| D→H completion token controls release | Done — `test_d2h_registered_calls_synchronize` |
-| Multiple D→H chunks produce correct ordered join | Done — `test_on_cpu_returns_correct_data` |
-| BeginStep and EndRun flush partial joins | Done — `test_pipeline_flush_partial` |
-| `on_gpu` returns independent copy | Done — `test_on_gpu_returns_independent_copy` |
-| `on_gpu_view` context manager records done-event on `__exit__` | Done — `test_on_gpu_view_records_done_event_on_exit` |
-| `on_gpu_view` retire succeeds after context exit | Done — `test_on_gpu_view_retire_safe_after_context_exit` |
-| `on_gpu_view` raises without lease | Done — `test_on_gpu_view_raises_without_lease` |
-| Budget check prevents OOM before cp.empty() | Done — `TestGpuBudget` (5 tests) |
-| Subbatch estimates stay within budget | Done — `test_subbatch_estimates_stay_within_budget` |
-| Variable event sizes split correctly | Done — `TestSplitSubbatches` |
-| D→H pipeline falls back to sync when all slots busy (no deadlock) | Done — `test_get_free_slot_returns_none_when_all_slots_busy` |
-| Async D→H resumes after a slot is freed | Done — `test_get_free_slot_returns_none_when_all_slots_busy` |
-| Concurrent dec_ref() calls produce correct _refs and return slot to queue once | Done — `test_dec_ref_race_lock_prevents_lost_update` |
-| Multiple BDs cannot exceed aggregate GPU budget | Not done — Phase 4 |
+- Aggregate GPU-memory coordination across multiple BD processes sharing one
+  device remains separate from the per-BD budget.
+- True GDS depends on filesystem and cuFile infrastructure. On Lustre/GPFS,
+  KvikIO uses the CPU-fallback path (storage to CPU DRAM to GPU VRAM).
+- Logical joins of many CPU results are separate from physical D2H chunking.
+  Compact downstream GPU reductions should transfer only their reduced result
+  rather than full calibrated detector planes.

--- a/psana/psana/gpu/gpu_calib.py
+++ b/psana/psana/gpu/gpu_calib.py
@@ -269,14 +269,9 @@ class GPUDetector:
         # One buffer per EventPool slot, grown lazily to fit the first batch.
         # Reused across batches to prevent CuPy pool fragmentation that causes
         # OOM with large batch sizes.  Each slot's buffer is written by the GPU
-        # calibration kernel and read by the user via GpuEventContext.on_gpu.
-        #
-        # Safety guarantee: the EventPool recycles slot N only after N+n_slots
-        # batches, by which point the user has consumed all GpuEventContext
-        # objects from that slot.  on_gpu arrays are views into this buffer —
-        # users who need to retain results beyond one event-loop cycle should
-        # call .on_cpu() to get an independent NumPy copy, then call
-        # free_calib_bufs() to reclaim GPU memory.
+        # calibration kernel and protected by the EventPool lease until its
+        # registered terminal consumer completes.  on_gpu returns an independent
+        # device copy; on_gpu_view keeps the slot leased through user GPU work.
         self._n_slots         = int(n_slots)
         self._budget          = budget  # _GpuBudget | None
         self._calib_slot_bufs = [None] * self._n_slots   # cp.ndarray per slot
@@ -557,24 +552,6 @@ class GPUDetector:
         # One allocation per stream per run — not per event.
         self._stream_peds[stream_id]  = cp.concatenate(peds_parts)
         self._stream_gmask[stream_id] = cp.concatenate(gmask_parts)
-
-    def free_calib_bufs(self):
-        """Release all pre-allocated per-slot calib_gpu buffers.
-
-        Call this when:
-          - You accumulate GpuEventContext objects across event-loop cycles
-            (e.g. ``results = list(run.events())``), in which case the
-            on_gpu arrays would alias into buffers that get overwritten.
-          - You want to reclaim GPU VRAM at the end of a run.
-
-        After calling this, process_batch() falls back to dynamic
-        allocation (one cp.empty() per batch), restoring normal behaviour
-        at the cost of CuPy pool growth over long runs.
-
-        Safe to call at any time — in-flight kernels have already read
-        from their slot's buffer before it is freed here.
-        """
-        self._calib_slot_bufs = [None] * self._n_slots
 
     def memory_bytes(self) -> dict:
         """Return current VRAM usage broken down by category.

--- a/psana/psana/gpu/gpu_events.py
+++ b/psana/psana/gpu/gpu_events.py
@@ -87,7 +87,7 @@ def _iter_step_events(batch_bytes, configs):
 class _PendingD2H:
     """Token held by GPUResult while its async D→H is in-flight.
 
-    Created by _D2hPipeline._flush_chunk() immediately after issuing
+    Created by _D2hPipeline._schedule_chunk() immediately after issuing
     cudaMemcpyAsync.  GPUResult.on_cpu calls .get() to wait for the
     transfer and retrieve the host copy.
 
@@ -180,23 +180,21 @@ class _PinnedSlot:
 class _D2hPipeline:
     """Internal GpuEvents D→H pipeline (not user-facing).
 
-    Issues async D→H from EventPool slot views to pinned host memory,
-    then yields contexts IMMEDIATELY — before the transfer completes.
-    GPUResult.on_cpu waits for the CUDA done-event lazily at the call
-    site, so the generator stays thin and D→H overlaps with whatever
-    work the user does between receiving a context and calling on_cpu.
+    Issues async D→H from an EventPool slot as soon as its final GPU work is
+    submitted.  Result delivery remains separate: GPUResult.on_cpu later waits
+    on the attached token and copies out of pinned memory.
 
     Activated by DataSource(gpu_d2h_chunk_size=N).  N=0 (default)
     bypasses the pipeline; on_cpu then triggers a blocking D→H on first
     access (existing behaviour).
     """
 
-    def __init__(self, det_key: str, chunk_size: int):
+    def __init__(self, det_key: str, chunk_size: int, max_inflight: int = 2):
         from queue import SimpleQueue
 
         self._key = det_key
         self._chunk_size = chunk_size
-        self._max_inflight = 2  # pinned slots; 2 lets one transfer while next fills
+        self._max_inflight = max(2, int(max_inflight))
 
         # _available is a SimpleQueue of free _PinnedSlot objects.
         # _get_free_slot() calls get_nowait() — O(1), thread-safe, no scan.
@@ -213,40 +211,32 @@ class _D2hPipeline:
         self._nrows: int | None = None
         self._ncols: int | None = None
 
-        # Accumulator for the current in-progress chunk.
-        self._chunk_buf: list = []  # list of (ctx, lease, arr)
+    def schedule(self, slot_record):
+        """Arm D→H for every matching result in one execution slot.
 
-    def add(self, ctx) -> list:
-        """Add one context.  Returns list of contexts ready to yield.
-
-        Contexts are returned immediately once their D→H has been
-        *issued* (not waited for).  The caller yields them; the user
-        completes the sync lazily via GPUResult.on_cpu.
+        This runs immediately after EventPool.submit().  It never waits for
+        normal asynchronous copies: the D→H stream waits on the slot's
+        result-ready event and records its own completion event.  If all pinned
+        buffers are retained, the result is copied synchronously now and cached
+        so a later on_cpu() can never read a reused GPU slot.
         """
-        arr = ctx._gpu_results.get(self._key)
-        lease = ctx._leases.get(self._key)
+        items = []
+        key = self._key
+        for evt in slot_record.cpu_evts:
+            ts = evt.timestamp
+            arr = slot_record.gpu_results_by_ts.get(ts, {}).get(key)
+            if arr is None:
+                continue
+            lease = slot_record.leases_by_ts.get(ts, {}).get(key)
+            items.append((ts, lease, arr))
 
-        if arr is None:
-            return [ctx]  # no GPU data for this key — pass through
-
+        if not items:
+            return
         if self._n_segs is None:
-            self._init(arr)
+            self._init(items[0][2])
 
-        self._chunk_buf.append((ctx, lease, arr))
-
-        if len(self._chunk_buf) >= self._chunk_size:
-            return self._flush_chunk()
-        return []
-
-    def flush(self) -> list:
-        """Issue D→H for any partial chunk; return all buffered contexts.
-
-        Called at EndRun, BeginStep, and end of each batch so no event
-        is stranded in _chunk_buf indefinitely.
-        """
-        if self._chunk_buf:
-            return self._flush_chunk()
-        return []
+        for start in range(0, len(items), self._chunk_size):
+            self._schedule_chunk(slot_record, items[start:start + self._chunk_size])
 
     def pinned_bytes(self) -> int:
         """Return bytes of pinned (page-locked) host memory currently
@@ -278,50 +268,32 @@ class _D2hPipeline:
         removes the slot from the free pool — eliminating the Semaphore +
         in_use scan that three separate mechanisms previously handled.
 
-        Returns None (sync D→H fallback) when the queue is empty so the
-        generator never deadlocks when the user accumulates contexts before
-        calling on_cpu (e.g. list(run.events())).
-
-        In the standard sequential for-loop a slot is always available here
-        (the previous chunk's slot is returned to the queue by dec_ref()
-        before the next chunk is flushed), so None is never returned.
+        Returns None when the queue is empty.  schedule() then materializes an
+        independent CPU result before the execution slot can be reused.
         """
         try:
             return self._available.get_nowait()
         except Exception:
-            return None   # queue empty — caller falls back to sync on_cpu
+            return None   # queue empty — schedule() materializes CPU data now
 
-    def _flush_chunk(self) -> list:
-        """Issue async D→H for the current chunk; attach _pending_d2h;
-        return all events immediately.
-
-        If a free pinned slot is available (_free_slots semaphore count > 0)
-        the D→H transfer is issued asynchronously and all events are returned
-        immediately (lazy-sync path).
-
-        If no slot is free (all max_inflight slots are occupied) the events
-        are returned without _pending_d2h and on_cpu will fall back to the
-        synchronous self._arr.get() path.  This prevents the generator from
-        deadlocking when the user accumulates contexts before calling on_cpu.
-        """
+    def _schedule_chunk(self, slot_record, chunk):
+        """Issue one pinned D→H chunk, or materialize a safe CPU fallback."""
         import cupy as cp
-        from psana.gpu.context import GPUResult
-
-        chunk = self._chunk_buf
-        self._chunk_buf = []
         n_evts = len(chunk)
 
         pslot = self._get_free_slot()
 
-        # ── Fallback: no free pinned slot ────────────────────────────────
-        # All max_inflight slots are occupied (user has not yet called on_cpu
-        # on every event from the previous chunks).  Yield events without
-        # _pending_d2h so on_cpu falls back to the synchronous self._arr.get()
-        # path — correct but without async overlap.  This also prevents the
-        # generator from deadlocking when the user accumulates events before
-        # calling on_cpu (e.g. list(run.events())).
+        # No free pinned slot: materialize while the device lease is valid.
+        # Deferring arr.get() until on_cpu() would allow this execution slot to
+        # be overwritten first when callers retain event contexts.
         if pslot is None:
-            return [ctx for ctx, _, _ in chunk]
+            for ts, lease, arr in chunk:
+                if lease is not None and lease.calib_done is not None:
+                    lease.calib_done.synchronize()
+                slot_record.cpu_results_by_ts.setdefault(ts, {})[
+                    self._key
+                ] = arr.get()
+            return
 
         # ── Issue async D→H ───────────────────────────────────────────────
         pslot.claim(n_evts)
@@ -330,7 +302,7 @@ class _D2hPipeline:
         dst_base = pslot.arr.ctypes.data
         leases_out = []
 
-        for i, (ctx, lease, arr) in enumerate(chunk):
+        for i, (_, lease, arr) in enumerate(chunk):
             if lease is not None and lease.calib_done is not None:
                 stream.wait_event(lease.calib_done)
             cp.cuda.runtime.memcpyAsync(
@@ -348,19 +320,12 @@ class _D2hPipeline:
         for lease in leases_out:
             lease.register_d2h_done(pslot.done_event)
 
-        # Attach _pending_d2h to each GPUResult and yield immediately.
-        key = self._key
-        results = []
-        for i, (ctx, lease, arr) in enumerate(chunk):
-            # Ensure GPUResult is cached so we can attach pending_d2h.
-            if key not in ctx._cache:
-                ctx._cache[key] = GPUResult(
-                    ctx._gpu_results.get(key),
-                    lease=ctx._leases.get(key),
-                )
-            ctx._cache[key]._pending_d2h = _PendingD2H(pslot, i, self._n_segs)
-            results.append(ctx)
-        return results
+        # Store host-result tokens on the execution record.  Context delivery
+        # later attaches them to GPUResult without scheduling new CUDA work.
+        for i, (ts, _, _) in enumerate(chunk):
+            slot_record.pending_d2h_by_ts.setdefault(ts, {})[self._key] = (
+                _PendingD2H(pslot, i, self._n_segs)
+            )
 
 
 def _fmt_mib(n: int) -> str:
@@ -477,6 +442,10 @@ class GpuEvents:
         self.router = DetectorRouter()
         self.event_pool = None
         self.gpu_reader = None
+        # At most one KvikIO read is pre-issued ahead of the CPU event loop.
+        # Keep explicit ownership so generator close/early termination can
+        # drain it before gpu_reader.close() releases its buffers.
+        self._pending_gpu_read = None
 
         self._setup_detectors(calib_leader=calib_leader)
 
@@ -727,6 +696,7 @@ class GpuEvents:
                 f"{det_name}.calib": _D2hPipeline(
                     det_key=f"{det_name}.calib",
                     chunk_size=chunk_size,
+                    max_inflight=n_streams,
                 )
                 for det_name in self.gpu_det_names
             }
@@ -940,68 +910,140 @@ class GpuEvents:
 
         return end_run_seen
 
-    def _make_context(self, evt, gpu_results, leases=None):
-        gpu_results = _apply_full_routing(
-            gpu_results,
-            evt,
-            self.gpu_detectors,
-            self.router,
-        )
+    def _make_context(self, evt, gpu_results, leases=None,
+                      pending_d2h=None, cpu_results=None,
+                      device_released=False):
         return GpuEventContext(
             evt=evt,
             gpu_results=gpu_results,
             cpu_dets=self.cpu_dets,
             router=self.router,
             leases=leases,
+            pending_d2h=pending_d2h,
+            cpu_results=cpu_results,
+            device_released=device_released,
         )
 
-    def _push_context(self, ctx):
-        """Feed one context through D→H pipelines; yield when ready."""
-        if not self._d2h_pipelines:
-            yield ctx
-            return
-        # Feed through every active pipeline (one per det key).
-        # A context is only yielded once ALL pipelines have finished with it.
-        # For the common single-detector case this is a single iteration.
-        ready = [ctx]
-        for pipe in self._d2h_pipelines.values():
-            next_ready = []
-            for c in ready:
-                next_ready.extend(pipe.add(c))
-            ready = next_ready
-        yield from ready
+    def _finalize_slot_results(self, gpu_results_by_ts, cpu_evts, stream):
+        """Queue full-result routing on the slot's producer stream."""
+        with stream:
+            for evt in cpu_evts:
+                ts = evt.timestamp
+                gpu_results_by_ts[ts] = _apply_full_routing(
+                    gpu_results_by_ts.get(ts, {}),
+                    evt,
+                    self.gpu_detectors,
+                    self.router,
+                )
+        return gpu_results_by_ts
 
-    def _yield_ready(self, ready):
+    def _submit_gpu(self, subbatch, gpu_read, cpu_evts):
+        """Submit one device slot and arm its automatic D→H immediately."""
+        record = self.event_pool.submit(
+            subbatch,
+            gpu_read,
+            cpu_evts,
+            self.gpu_detectors,
+            finalize_results=self._finalize_slot_results,
+        )
+        for pipe in self._d2h_pipelines.values():
+            pipe.schedule(record)
+        return record
+
+    @staticmethod
+    def _is_fully_host_backed(ready):
+        """Return True when every slot-backed result has a host handoff.
+
+        A pending pinned D2H token or an independent CPU fallback both make
+        the corresponding result safe after its device slot is reused.
+        """
+        if ready is None:
+            return True
+        for ts, results in ready.gpu_results_by_ts.items():
+            pending = ready.pending_d2h_by_ts.get(ts, {})
+            cached = ready.cpu_results_by_ts.get(ts, {})
+            if any(key not in pending and key not in cached for key in results):
+                return False
+        return True
+
+    def _yield_ready(self, ready, device_released=False):
         if ready is None:
             return
-        gpu_results_by_ts, cpu_evts, leases_by_ts = ready
         # Log after the first batch: slot buffers have grown to their
         # initial sizes so this shows the steady-state allocation.
-        if not self._first_batch_logged and cpu_evts:
+        if not self._first_batch_logged and ready.cpu_evts:
             self._first_batch_logged = True
             self.log_memory("first_batch")
-        for evt in cpu_evts:
-            ctx = self._make_context(
+        for evt in ready.cpu_evts:
+            ts = evt.timestamp
+            gpu_results = ready.gpu_results_by_ts.get(ts, {})
+            if device_released:
+                # Preserve the result-key API but never retain a stale view
+                # into a slot which the replacement H2D may now overwrite.
+                gpu_results = {key: None for key in gpu_results}
+            yield self._make_context(
                 evt,
-                gpu_results_by_ts.get(evt.timestamp, {}),
-                leases=leases_by_ts.get(evt.timestamp, {}),
+                gpu_results,
+                leases={} if device_released else ready.leases_by_ts.get(ts, {}),
+                pending_d2h=ready.pending_d2h_by_ts.pop(ts, {}),
+                cpu_results=ready.cpu_results_by_ts.get(ts, {}),
+                device_released=device_released,
             )
-            yield from self._push_context(ctx)
-        # Flush any partial D→H chunk at the batch boundary so events are
-        # never stranded in _chunk_buf when batch_size % chunk_size != 0.
-        yield from self._flush_d2h_pipelines()
 
-    def _flush_d2h_pipelines(self):
-        """Flush partial D→H chunks at EndRun, BeginStep, or end of pool drain.
+    def _issue_gpu_read(self, subbatch, slot_id):
+        """Issue and own the single read allowed ahead of CPU processing."""
+        if getattr(self, '_pending_gpu_read', None) is not None:
+            raise RuntimeError("a pre-issued GPU read is already outstanding")
+        pending = self.gpu_reader.issue_batch(subbatch, self.dm, slot_id=slot_id)
+        self._pending_gpu_read = pending
+        return pending
 
-        With the lazy-sync design, all events have already been yielded;
-        this only handles events still buffered in _chunk_buf (partial
-        chunk not yet flushed because it didn't reach chunk_size).
-        """
-        if not self._d2h_pipelines:
+    def _wait_gpu_read(self, pending):
+        """Complete a read and relinquish its controller-side ownership."""
+        if getattr(self, '_pending_gpu_read', None) is not pending:
+            raise RuntimeError("attempted to wait for an unowned GPU read")
+        try:
+            return self.gpu_reader.wait_batch(pending)
+        finally:
+            self._pending_gpu_read = None
+
+    def _drain_pending_gpu_read(self):
+        """Finish a pre-issued read before the reader and buffers are closed."""
+        pending = getattr(self, '_pending_gpu_read', None)
+        if pending is None:
             return
-        for pipe in self._d2h_pipelines.values():
-            yield from pipe.flush()
+        try:
+            self.gpu_reader.wait_batch(pending)
+        finally:
+            self._pending_gpu_read = None
+
+    def _retire_issue_and_yield(self, subbatch):
+        """Retire one slot, issue its replacement read, and yield its result.
+
+        Automatic-D2H results are already host-backed.  Their terminal D2H
+        consumer is joined first, then the freed slot receives the replacement
+        H2D before CPU code sees the old event.  External-GPU mode retains the
+        original yield-first registration window so a user kernel can attach a
+        completion event before the slot is released.
+        """
+        ready = self.event_pool.begin_retire_next()
+        release_before_yield = (
+            bool(self._d2h_pipelines) and self._is_fully_host_backed(ready)
+        )
+
+        if release_before_yield:
+            self.event_pool.finish_retire_next()
+            slot = self.event_pool.next_slot_id
+            pending = self._issue_gpu_read(subbatch, slot)
+            yield from self._yield_ready(ready, device_released=True)
+            return pending
+
+        try:
+            yield from self._yield_ready(ready)
+        finally:
+            self.event_pool.finish_retire_next()
+        slot = self.event_pool.next_slot_id
+        return self._issue_gpu_read(subbatch, slot)
 
     def _flush_event_pool(self):
         for slot_data in self.event_pool.flush():
@@ -1034,22 +1076,11 @@ class GpuEvents:
                     all_subbatches.extend(self._split_subbatches(gpu_view))
 
                 if all_subbatches:
-                    # Two-phase retirement keeps the outgoing slot owned
-                    # while its yielded context registers external work.
-                    ready_0 = self.event_pool.begin_retire_next()
-                    try:
-                        yield from self._yield_ready(ready_0)
-                    finally:
-                        self.event_pool.finish_retire_next()
-
-                    # Only now may the reader overwrite this slot.  Its I/O
-                    # still overlaps the CPU EventManager loop below.
-                    slot_0  = self.event_pool.next_slot_id
                     first_pending = (
                         all_subbatches[0],
-                        self.gpu_reader.issue_batch(
-                            all_subbatches[0], self.dm, slot_id=slot_0
-                        ),
+                        (yield from self._retire_issue_and_yield(
+                            all_subbatches[0]
+                        )),
                     )
 
                 # ── CPU path ─────────────────────────────────────────────────
@@ -1094,26 +1125,14 @@ class GpuEvents:
                             # Subbatch 0: reads were already issued before the
                             # CPU loop.  Just wait for them to complete.
                             _, pending_0 = first_pending
-                            gpu_read = self.gpu_reader.wait_batch(pending_0)
-                            self.event_pool.submit(
-                                subbatch, gpu_read, sb_cpu, self.gpu_detectors
-                            )
+                            gpu_read = self._wait_gpu_read(pending_0)
+                            self._submit_gpu(subbatch, gpu_read, sb_cpu)
                         else:
-                            # Subbatches 1+: two-phase retire, then issue the
-                            # next read only after the old slot is released.
-                            ready = self.event_pool.begin_retire_next()
-                            try:
-                                yield from self._yield_ready(ready)
-                            finally:
-                                self.event_pool.finish_retire_next()
-                            slot  = self.event_pool.next_slot_id
-                            pending = self.gpu_reader.issue_batch(
-                                subbatch, self.dm, slot_id=slot
+                            pending = yield from self._retire_issue_and_yield(
+                                subbatch
                             )
-                            gpu_read = self.gpu_reader.wait_batch(pending)
-                            self.event_pool.submit(
-                                subbatch, gpu_read, sb_cpu, self.gpu_detectors
-                            )
+                            gpu_read = self._wait_gpu_read(pending)
+                            self._submit_gpu(subbatch, gpu_read, sb_cpu)
                 else:
                     # No GPU batch — yield CPU-only events directly.
                     for evt in cpu_evts:
@@ -1124,4 +1143,7 @@ class GpuEvents:
                     break
         finally:
             if self.gpu_reader is not None:
-                self.gpu_reader.close()
+                try:
+                    self._drain_pending_gpu_read()
+                finally:
+                    self.gpu_reader.close()

--- a/psana/psana/gpu/gpu_events.py
+++ b/psana/psana/gpu/gpu_events.py
@@ -3,6 +3,7 @@ import math
 import os
 import sys
 from dataclasses import dataclass, field
+from queue import Empty, SimpleQueue
 
 import numpy as np
 
@@ -189,12 +190,10 @@ class _D2hPipeline:
     access (existing behaviour).
     """
 
-    def __init__(self, det_key: str, chunk_size: int, max_inflight: int = 2):
-        from queue import SimpleQueue
-
+    def __init__(self, det_key: str, chunk_size: int, n_pinned_slots: int = 2):
         self._key = det_key
         self._chunk_size = chunk_size
-        self._max_inflight = max(2, int(max_inflight))
+        self._n_pinned_slots = max(2, int(n_pinned_slots))
 
         # _available is a SimpleQueue of free _PinnedSlot objects.
         # _get_free_slot() calls get_nowait() — O(1), thread-safe, no scan.
@@ -255,7 +254,7 @@ class _D2hPipeline:
         self._n_segs = int(arr.shape[0])
         self._nrows = int(arr.shape[1])
         self._ncols = int(arr.shape[2])
-        for _ in range(self._max_inflight):
+        for _ in range(self._n_pinned_slots):
             slot = _PinnedSlot(self._n_segs, self._nrows, self._ncols, self._chunk_size, self._available)
             self._pinned_pool.append(slot)
             self._available.put(slot)   # all slots start free
@@ -273,7 +272,7 @@ class _D2hPipeline:
         """
         try:
             return self._available.get_nowait()
-        except Exception:
+        except Empty:
             return None   # queue empty — schedule() materializes CPU data now
 
     def _schedule_chunk(self, slot_record, chunk):
@@ -288,9 +287,9 @@ class _D2hPipeline:
         # be overwritten first when callers retain event contexts.
         if pslot is None:
             for ts, lease, arr in chunk:
-                if lease is not None and lease.calib_done is not None:
-                    lease.calib_done.synchronize()
-                slot_record.cpu_results_by_ts.setdefault(ts, {})[
+                if lease is not None and lease.result_ready is not None:
+                    lease.result_ready.synchronize()
+                slot_record.cached_cpu_results_by_ts.setdefault(ts, {})[
                     self._key
                 ] = arr.get()
             return
@@ -303,8 +302,8 @@ class _D2hPipeline:
         leases_out = []
 
         for i, (_, lease, arr) in enumerate(chunk):
-            if lease is not None and lease.calib_done is not None:
-                stream.wait_event(lease.calib_done)
+            if lease is not None and lease.result_ready is not None:
+                stream.wait_event(lease.result_ready)
             cp.cuda.runtime.memcpyAsync(
                 dst_base + i * row_nbytes,
                 arr.data.ptr,
@@ -318,7 +317,7 @@ class _D2hPipeline:
         # Record done_event and register on leases.
         pslot.done_event.record(stream)
         for lease in leases_out:
-            lease.register_d2h_done(pslot.done_event)
+            lease.register_consumer_done(pslot.done_event)
 
         # Store host-result tokens on the execution record.  Context delivery
         # later attaches them to GPUResult without scheduling new CUDA work.
@@ -676,14 +675,14 @@ class GpuEvents:
             self.cpu_dets[det_name] = self.run.Detector(det_name)
             self.router.register_cpu(det_name)
 
-        n_streams = getattr(self.dsparms, "n_gpu_streams", 2)
-        self.event_pool = EventPool(n=n_streams)
+        pool_depth = getattr(self.dsparms, "n_gpu_streams", 2)
+        self.event_pool = EventPool(n=pool_depth)
 
         # KvikioGpuReader: pre-allocate one data_gpu buffer per slot.
         # _gpu_budget was already created in _setup_detectors() above and
         # is shared with every GPUDetector so all allocations are counted
         # against the same limit.
-        self.gpu_reader = KvikioGpuReader(n_slots=n_streams, budget=self._gpu_budget)
+        self.gpu_reader = KvikioGpuReader(n_slots=pool_depth, budget=self._gpu_budget)
 
         # Internal D→H pipeline — activated when gpu_d2h_chunk_size > 0.
         # Transfers calibrated results to pinned host memory in chunks so that
@@ -696,7 +695,7 @@ class GpuEvents:
                 f"{det_name}.calib": _D2hPipeline(
                     det_key=f"{det_name}.calib",
                     chunk_size=chunk_size,
-                    max_inflight=n_streams,
+                    n_pinned_slots=pool_depth,
                 )
                 for det_name in self.gpu_det_names
             }
@@ -862,15 +861,6 @@ class GpuEvents:
                 self._batch_iter = next(self.smdr_man)
                 self._has_gpu_batch_iter = hasattr(self._batch_iter, "next_with_gpu")
 
-    def free_calib_bufs(self):
-        """Release pre-allocated calib_gpu slot buffers for all GPU detectors.
-
-        Delegates to GPUDetector.free_calib_bufs() for each detector.
-        See GPUDetector.free_calib_bufs() for usage guidance.
-        """
-        for det_info in self.gpu_detectors.values():
-            det_info[1].free_calib_bufs()
-
     def _dispatch_transition(self, service, dgrams):
         if service == TransitionId.BeginStep:
             for det_info in self.gpu_detectors.values():
@@ -911,7 +901,7 @@ class GpuEvents:
         return end_run_seen
 
     def _make_context(self, evt, gpu_results, leases=None,
-                      pending_d2h=None, cpu_results=None,
+                      pending_d2h=None, cached_cpu_results=None,
                       device_released=False):
         return GpuEventContext(
             evt=evt,
@@ -920,7 +910,7 @@ class GpuEvents:
             router=self.router,
             leases=leases,
             pending_d2h=pending_d2h,
-            cpu_results=cpu_results,
+            cached_cpu_results=cached_cpu_results,
             device_released=device_released,
         )
 
@@ -961,7 +951,7 @@ class GpuEvents:
             return True
         for ts, results in ready.gpu_results_by_ts.items():
             pending = ready.pending_d2h_by_ts.get(ts, {})
-            cached = ready.cpu_results_by_ts.get(ts, {})
+            cached = ready.cached_cpu_results_by_ts.get(ts, {})
             if any(key not in pending and key not in cached for key in results):
                 return False
         return True
@@ -986,7 +976,7 @@ class GpuEvents:
                 gpu_results,
                 leases={} if device_released else ready.leases_by_ts.get(ts, {}),
                 pending_d2h=ready.pending_d2h_by_ts.pop(ts, {}),
-                cpu_results=ready.cpu_results_by_ts.get(ts, {}),
+                cached_cpu_results=ready.cached_cpu_results_by_ts.get(ts, {}),
                 device_released=device_released,
             )
 

--- a/psana/psana/gpu/gpu_events.py
+++ b/psana/psana/gpu/gpu_events.py
@@ -167,13 +167,15 @@ class _PinnedSlot:
         The decrement-and-check is protected by _refs_lock so that
         concurrent dec_ref() calls from different threads (e.g. when
         multiple events from the same chunk have on_cpu called in parallel)
-        cannot race and produce a lost update on _refs.
+        cannot race and produce a lost update on _refs.  Releases after the
+        reference count reaches zero are ignored so a slot is never queued
+        in the free pool more than once.
         """
         with self._refs_lock:
+            if self._refs <= 0:
+                return
             self._refs -= 1
-            freed = self._refs <= 0
-            if freed:
-                self._refs = 0
+            freed = self._refs == 0
         if freed:
             self._available.put(self)  # return slot to the free pool
 

--- a/psana/psana/gpu/gpu_events.py
+++ b/psana/psana/gpu/gpu_events.py
@@ -1034,9 +1034,16 @@ class GpuEvents:
                     all_subbatches.extend(self._split_subbatches(gpu_view))
 
                 if all_subbatches:
-                    # Retire the slot that subbatch 0 will write into, then
-                    # yield its results, then issue subbatch 0's reads.
-                    ready_0 = self.event_pool.retire_next()
+                    # Two-phase retirement keeps the outgoing slot owned
+                    # while its yielded context registers external work.
+                    ready_0 = self.event_pool.begin_retire_next()
+                    try:
+                        yield from self._yield_ready(ready_0)
+                    finally:
+                        self.event_pool.finish_retire_next()
+
+                    # Only now may the reader overwrite this slot.  Its I/O
+                    # still overlaps the CPU EventManager loop below.
                     slot_0  = self.event_pool.next_slot_id
                     first_pending = (
                         all_subbatches[0],
@@ -1044,7 +1051,6 @@ class GpuEvents:
                             all_subbatches[0], self.dm, slot_id=slot_0
                         ),
                     )
-                    yield from self._yield_ready(ready_0)
 
                 # ── CPU path ─────────────────────────────────────────────────
                 # EventManager loop runs while subbatch 0 reads are in-flight.
@@ -1093,13 +1099,17 @@ class GpuEvents:
                                 subbatch, gpu_read, sb_cpu, self.gpu_detectors
                             )
                         else:
-                            # Subbatches 1+: full retire/issue/wait/submit cycle.
-                            ready = self.event_pool.retire_next()
+                            # Subbatches 1+: two-phase retire, then issue the
+                            # next read only after the old slot is released.
+                            ready = self.event_pool.begin_retire_next()
+                            try:
+                                yield from self._yield_ready(ready)
+                            finally:
+                                self.event_pool.finish_retire_next()
                             slot  = self.event_pool.next_slot_id
                             pending = self.gpu_reader.issue_batch(
                                 subbatch, self.dm, slot_id=slot
                             )
-                            yield from self._yield_ready(ready)
                             gpu_read = self.gpu_reader.wait_batch(pending)
                             self.event_pool.submit(
                                 subbatch, gpu_read, sb_cpu, self.gpu_detectors

--- a/psana/psana/gpu/gpu_mpi_benchmark.py
+++ b/psana/psana/gpu/gpu_mpi_benchmark.py
@@ -281,7 +281,8 @@ def main():
     p.add_argument('--batch-size', type=int, default=10,
                    help='GPU batch size (default 10)')
     p.add_argument('--pool-depth', type=int, default=4,
-                   help='EventPool depth / n_gpu_streams (default 4)')
+                   help='EventPool depth / n_gpu_streams '
+                        '(benchmark default 4; DataSource default 2)')
     p.add_argument('--single-gpu-baseline-ms', type=float, default=0.0,
                    metavar='MS',
                    help='Single-GPU amortised ms/evt from gpu_performance_benchmark.py '

--- a/psana/psana/gpu/gpu_mpi_perf_compare.py
+++ b/psana/psana/gpu/gpu_mpi_perf_compare.py
@@ -410,7 +410,8 @@ def main():
     p.add_argument("--n-events", type=int, default=50, help="Events to time per BD rank (default 50)")
     p.add_argument("--n-warmup", type=int, default=5, help="Warmup events excluded from timing (default 5)")
     p.add_argument("--batch-size", type=int, default=10, help="GPU batch size for a single run (default 10)")
-    p.add_argument("--pool-depth", type=int, default=4, help="EventPool depth / n_gpu_streams (default 4)")
+    p.add_argument("--pool-depth", type=int, default=4,
+                   help="EventPool depth / n_gpu_streams (benchmark default 4; DataSource default 2)")
     p.add_argument("--batch-sizes", help="Comma-separated batch sizes to sweep, e.g. 10,20,30,50")
     p.add_argument("--pool-depths", help="Comma-separated pool depths to sweep, e.g. 2,4")
     p.add_argument("--scaling", action="store_true", help="GPU batch-size scaling sweep (bs = 1, 2, 5, 10, 20)")

--- a/psana/psana/gpu/gpu_performance_benchmark.py
+++ b/psana/psana/gpu/gpu_performance_benchmark.py
@@ -371,8 +371,9 @@ def main():
     p.add_argument('--batch-size', type=int, default=5,
                    help='GPU batch size (default 5)')
     p.add_argument('--pool-depth', type=int, default=4,
-                   help='EventPool depth n_gpu_streams (default 4); '
-                        'more depth = more concurrent GDS reads = higher NVMe throughput')
+                   help='EventPool depth / n_gpu_streams '
+                        '(benchmark default 4; DataSource default 2); '
+                        'more depth permits more execution pipelines in flight')
     p.add_argument('--hit-pct',    type=int, default=10,
                    help='Simulated hit rate for selective D->H (default 10%%)')
     p.add_argument('--no-scaling', action='store_true',

--- a/psana/psana/gpu/gpu_stream.py
+++ b/psana/psana/gpu/gpu_stream.py
@@ -3,7 +3,7 @@
 EventPool manages N in-flight calibration batches.  Each slot follows
 the state machine from gpu_memory_backpressure_and_async_join.md:
 
-    FREE → READING/COMPUTING → RESULT_READY → D2H_IN_FLIGHT → FREE
+    FREE → READING/COMPUTING → RESULT_READY → CONSUMER_IN_FLIGHT → FREE
 
 Slot leases and CUDA completion tokens connect the producer to its terminal
 consumer.  A slot may not be recycled until every consumer (automatic D2H or
@@ -25,7 +25,7 @@ class _EventSlot:
     leases: list
     leases_by_ts: dict
     pending_d2h_by_ts: dict = field(default_factory=dict)
-    cpu_results_by_ts: dict = field(default_factory=dict)
+    cached_cpu_results_by_ts: dict = field(default_factory=dict)
 
 
 class EventPool:
@@ -37,13 +37,14 @@ class EventPool:
                          event; create one SlotLease per result.
       2. automatic D2H may be armed immediately against that event.
       3. begin_retire_next() — synchronise the producer stream but retain
-                               ownership of the outgoing slot while results
-                               are delivered.
+                               ownership of the outgoing slot.
       4. finish_retire_next() — wait for each registered terminal consumer,
                                 then release the slot for reuse.
 
-    The caller (GpuEvents) must complete both retirement phases before
-    submit() so the outgoing slot is fully drained before overwrite.
+    The caller (GpuEvents) must complete both retirement phases before submit()
+    so the outgoing slot is fully drained before overwrite.  External-GPU mode
+    yields between the phases so user work can register its completion event;
+    automatic-D2H mode may finish retirement before yielding a host result.
 
     Parameters
     ----------
@@ -77,10 +78,10 @@ class EventPool:
         """Synchronize the outgoing producer but retain its slot lease.
 
         This is phase one of retirement.  The returned result is safe to
-        expose to the caller, but its slot remains occupied so a later
-        submit cannot overwrite it.  The caller must yield the result and
-        then call finish_retire_next(), allowing a consumer created during
-        that yield to register its completion event first.
+        expose to the caller, but its slot remains occupied so a later submit
+        cannot overwrite it.  Before calling finish_retire_next(), the caller
+        must ensure that any external consumer has registered its completion
+        event.  Automatic consumers may already have registered at submission.
 
         Returns the occupied _EventSlot, or None if the slot is empty.  Its
         arrays remain valid through finish_retire_next().
@@ -169,17 +170,17 @@ class EventPool:
         # Record ONE result-ready event after calibration and any final routing
         # work are queued.  All results share this event because they run on the
         # same slot stream.
-        calib_done = cp.cuda.Event(disable_timing=True)
-        calib_done.record(stream)
+        result_ready = cp.cuda.Event(disable_timing=True)
+        result_ready.record(stream)
 
         # Create one SlotLease per (timestamp, det, result_type) — each
-        # gets the shared calib_done event but its own view (array slice).
+        # gets the shared result_ready event but its own view (array slice).
         leases_by_ts: dict = {}   # {ts: {key: SlotLease}}
         all_leases: list  = []
         for ts, ts_dict in gpu_results_by_ts.items():
             ts_leases = {}
             for key, arr in ts_dict.items():
-                lease = SlotLease(calib_done)
+                lease = SlotLease(result_ready)
                 ts_leases[key] = lease
                 all_leases.append(lease)
             leases_by_ts[ts] = ts_leases

--- a/psana/psana/gpu/gpu_stream.py
+++ b/psana/psana/gpu/gpu_stream.py
@@ -21,12 +21,14 @@ class EventPool:
       1. submit()      — launch calibration kernels on the slot's stream;
                          record one calib_done CUDA event covering all
                          kernels; create one SlotLease per event.
-      2. retire_next() — wait for each SlotLease's consumer to complete
-                         (e.g. D→H), then synchronise the calib stream
-                         and yield the results for the caller to process.
+      2. begin_retire_next() — synchronise the producer stream but retain
+                               ownership of the outgoing slot.
+      3. caller yields results — consumers may now register completion.
+      4. finish_retire_next() — wait for each registered consumer, then
+                                release the slot for reuse.
 
-    The caller (GpuEvents) must call retire_next() before submit() so
-    the outgoing slot is fully drained before its buffers are overwritten.
+    The caller (GpuEvents) must complete both retirement phases before
+    submit() so the outgoing slot is fully drained before overwrite.
 
     Parameters
     ----------
@@ -42,6 +44,10 @@ class EventPool:
         # leases is a flat list of all SlotLease objects for that slot.
         self._slots: list = [None] * n
         self._write_idx = 0
+        # Slot currently exposed between begin_retire_next() and
+        # finish_retire_next().  Keeping it in _slots preserves ownership
+        # while the yielded event registers an external completion token.
+        self._retiring = None
 
     # ------------------------------------------------------------------
     # Main interface
@@ -52,33 +58,45 @@ class EventPool:
         """Slot index that the next submitted batch will occupy."""
         return self._write_idx % self._n
 
-    def retire_next(self):
-        """Wait for all consumers to finish, then release the next slot.
+    def begin_retire_next(self):
+        """Synchronize the outgoing producer but retain its slot lease.
 
-        Phase 1: before synchronising the calibration stream, wait for
-        every SlotLease in the outgoing slot to signal that its D→H (or
-        other downstream consumer) has completed.  This guarantees the
-        slot buffers are not overwritten while data is still in transit.
+        This is phase one of retirement.  The returned result is safe to
+        expose to the caller, but its slot remains occupied so a later
+        submit cannot overwrite it.  The caller must yield the result and
+        then call finish_retire_next(), allowing a consumer created during
+        that yield to register its completion event first.
 
         Returns (gpu_results_by_ts, cpu_evts) or None if the slot is empty.
-        The returned arrays remain valid until submit() is called next.
+        The returned arrays remain valid through finish_retire_next().
         """
+        if self._retiring is not None:
+            raise RuntimeError("EventPool retirement already in progress")
+
         slot = self.next_slot_id
         old  = self._slots[slot]
         if old is None:
             return None
 
         old_results, old_evts, old_stream, old_leases, old_leases_by_ts = old
+        old_stream.synchronize()
+        self._retiring = (slot, old_leases)
+        return old_results, old_evts, old_leases_by_ts
 
-        # Wait for every consumer (D→H or downstream GPU kernel) that
-        # registered a completion token on one of this slot's leases.
-        for lease in old_leases:
+    def finish_retire_next(self):
+        """Wait for consumers registered after begin, then release the slot."""
+        if self._retiring is None:
+            return
+
+        slot, leases = self._retiring
+        # This lookup happens after the caller has consumed the yielded
+        # result.  In particular, on_gpu_view().__exit__ may have registered
+        # its external-kernel completion event during that interval.
+        for lease in leases:
             lease.wait_until_safe_to_reuse()
 
-        # Now safe to synchronise the calibration stream and recycle.
-        old_stream.synchronize()
         self._slots[slot] = None
-        return old_results, old_evts, old_leases_by_ts
+        self._retiring = None
 
     def submit(self, gv, gpu_read, cpu_evts: list, gpu_detectors: dict):
         """Queue calibration into the already-retired next slot.
@@ -87,7 +105,7 @@ class EventPool:
         are queued, then creates one SlotLease per event so downstream
         consumers can issue async D→H and release the slot when done.
 
-        Returns None.  Results come back via retire_next().
+        Returns None.  Results come back via begin_retire_next().
         """
         import cupy as cp
         from psana.gpu.context import SlotLease
@@ -95,7 +113,7 @@ class EventPool:
         slot   = self.next_slot_id
         if self._slots[slot] is not None:
             raise RuntimeError(
-                f"EventPool slot {slot} was submitted without retire_next()"
+                f"EventPool slot {slot} was submitted before retirement finished"
             )
         stream = self._streams[slot]
 
@@ -157,19 +175,24 @@ class EventPool:
     def flush(self):
         """Drain all remaining in-flight slots in submission order.
 
-        Waits for every consumer lease before synchronising each stream.
-        Yields (gpu_results_by_ts, cpu_evts) for each non-empty slot.
+        Synchronizes each producer, yields its results so consumers can
+        register completion, then waits for those consumers before clearing
+        the slot.  Yields (gpu_results_by_ts, cpu_evts) for each slot.
         """
         for i in range(self._n):
             slot = (self._write_idx + i) % self._n
             if self._slots[slot] is None:
                 continue
             results, evts, stream, leases, leases_by_ts = self._slots[slot]
-            for lease in leases:
-                lease.wait_until_safe_to_reuse()
             stream.synchronize()
-            yield results, evts, leases_by_ts
-            self._slots[slot] = None
+            try:
+                yield results, evts, leases_by_ts
+            finally:
+                # The yield above is the registration window.  This finally
+                # also protects generator close/early loop termination.
+                for lease in leases:
+                    lease.wait_until_safe_to_reuse()
+                self._slots[slot] = None
 
     # ------------------------------------------------------------------
     # Inspection

--- a/psana/psana/gpu/gpu_stream.py
+++ b/psana/psana/gpu/gpu_stream.py
@@ -5,13 +5,27 @@ the state machine from gpu_memory_backpressure_and_async_join.md:
 
     FREE → READING/COMPUTING → RESULT_READY → D2H_IN_FLIGHT → FREE
 
-Phase 1 of the design: slot leases and CUDA completion tokens.
-The calibration stream is no longer the only completion signal — a slot
-may not be recycled until every consumer (D2H or downstream GPU kernel)
-has registered completion via SlotLease.register_d2h_done().
+Slot leases and CUDA completion tokens connect the producer to its terminal
+consumer.  A slot may not be recycled until every consumer (automatic D2H or
+a downstream GPU kernel) has registered and completed its work.
 """
 
 import os
+from dataclasses import dataclass, field
+
+
+@dataclass
+class _EventSlot:
+    """One occupied execution slot and its eventual host-result handles."""
+
+    slot_id: int
+    gpu_results_by_ts: dict
+    cpu_evts: list
+    stream: object
+    leases: list
+    leases_by_ts: dict
+    pending_d2h_by_ts: dict = field(default_factory=dict)
+    cpu_results_by_ts: dict = field(default_factory=dict)
 
 
 class EventPool:
@@ -19,13 +33,14 @@ class EventPool:
 
     For each submitted batch:
       1. submit()      — launch calibration kernels on the slot's stream;
-                         record one calib_done CUDA event covering all
-                         kernels; create one SlotLease per event.
-      2. begin_retire_next() — synchronise the producer stream but retain
-                               ownership of the outgoing slot.
-      3. caller yields results — consumers may now register completion.
-      4. finish_retire_next() — wait for each registered consumer, then
-                                release the slot for reuse.
+                         finalize routed results; record one result-ready
+                         event; create one SlotLease per result.
+      2. automatic D2H may be armed immediately against that event.
+      3. begin_retire_next() — synchronise the producer stream but retain
+                               ownership of the outgoing slot while results
+                               are delivered.
+      4. finish_retire_next() — wait for each registered terminal consumer,
+                                then release the slot for reuse.
 
     The caller (GpuEvents) must complete both retirement phases before
     submit() so the outgoing slot is fully drained before overwrite.
@@ -40,8 +55,8 @@ class EventPool:
         import cupy as cp
         self._n = n
         self._streams = [cp.cuda.Stream(non_blocking=True) for _ in range(n)]
-        # Each slot: (gpu_results_by_ts, cpu_evts, stream, leases) | None
-        # leases is a flat list of all SlotLease objects for that slot.
+        # Each slot is an _EventSlot or None.  leases is a flat list of all
+        # SlotLease objects that protect buffers owned by that execution slot.
         self._slots: list = [None] * n
         self._write_idx = 0
         # Slot currently exposed between begin_retire_next() and
@@ -67,8 +82,8 @@ class EventPool:
         then call finish_retire_next(), allowing a consumer created during
         that yield to register its completion event first.
 
-        Returns (gpu_results_by_ts, cpu_evts) or None if the slot is empty.
-        The returned arrays remain valid through finish_retire_next().
+        Returns the occupied _EventSlot, or None if the slot is empty.  Its
+        arrays remain valid through finish_retire_next().
         """
         if self._retiring is not None:
             raise RuntimeError("EventPool retirement already in progress")
@@ -78,34 +93,39 @@ class EventPool:
         if old is None:
             return None
 
-        old_results, old_evts, old_stream, old_leases, old_leases_by_ts = old
-        old_stream.synchronize()
-        self._retiring = (slot, old_leases)
-        return old_results, old_evts, old_leases_by_ts
+        old.stream.synchronize()
+        self._retiring = old
+        return old
 
     def finish_retire_next(self):
         """Wait for consumers registered after begin, then release the slot."""
         if self._retiring is None:
             return
 
-        slot, leases = self._retiring
+        old = self._retiring
         # This lookup happens after the caller has consumed the yielded
         # result.  In particular, on_gpu_view().__exit__ may have registered
         # its external-kernel completion event during that interval.
-        for lease in leases:
+        for lease in old.leases:
             lease.wait_until_safe_to_reuse()
 
-        self._slots[slot] = None
+        self._slots[old.slot_id] = None
         self._retiring = None
 
-    def submit(self, gv, gpu_read, cpu_evts: list, gpu_detectors: dict):
+    def submit(self, gv, gpu_read, cpu_evts: list, gpu_detectors: dict,
+               finalize_results=None):
         """Queue calibration into the already-retired next slot.
 
-        Records a calib_done CUDA event after all calibration kernels
-        are queued, then creates one SlotLease per event so downstream
-        consumers can issue async D→H and release the slot when done.
+        Records a result-ready CUDA event after calibration and final routing
+        are queued, then creates one SlotLease per result so downstream
+        consumers can release the slot when done.
 
-        Returns None.  Results come back via begin_retire_next().
+        ``finalize_results`` may enqueue routing or assembly work on the same
+        producer stream before the final result-ready event is recorded.
+
+        Returns the occupied _EventSlot.  Automatic consumers such as D2H may
+        attach their completion tokens immediately; results are delivered later
+        by begin_retire_next().
         """
         import cupy as cp
         from psana.gpu.context import SlotLease
@@ -141,10 +161,14 @@ class EventPool:
                 if ec.image_gpu is not None:
                     ts_dict[f'{det_name}.image'] = ec.image_gpu
 
-        # Record ONE calib_done event after all kernels are queued.
-        # All events in this batch share this single event — they all
-        # ran on the same stream so any one of them completing means all
-        # preceding work is done.
+        if finalize_results is not None:
+            gpu_results_by_ts = finalize_results(
+                gpu_results_by_ts, cpu_evts, stream
+            )
+
+        # Record ONE result-ready event after calibration and any final routing
+        # work are queued.  All results share this event because they run on the
+        # same slot stream.
         calib_done = cp.cuda.Event(disable_timing=True)
         calib_done.record(stream)
 
@@ -168,29 +192,37 @@ class EventPool:
             except Exception:
                 pass
 
-        self._slots[slot] = (gpu_results_by_ts, list(cpu_evts),
-                             stream, all_leases, leases_by_ts)
+        record = _EventSlot(
+            slot_id=slot,
+            gpu_results_by_ts=gpu_results_by_ts,
+            cpu_evts=list(cpu_evts),
+            stream=stream,
+            leases=all_leases,
+            leases_by_ts=leases_by_ts,
+        )
+        self._slots[slot] = record
         self._write_idx += 1
+        return record
 
     def flush(self):
         """Drain all remaining in-flight slots in submission order.
 
-        Synchronizes each producer, yields its results so consumers can
+        Synchronizes each producer, yields its _EventSlot so consumers can
         register completion, then waits for those consumers before clearing
-        the slot.  Yields (gpu_results_by_ts, cpu_evts) for each slot.
+        the slot.
         """
         for i in range(self._n):
             slot = (self._write_idx + i) % self._n
             if self._slots[slot] is None:
                 continue
-            results, evts, stream, leases, leases_by_ts = self._slots[slot]
-            stream.synchronize()
+            record = self._slots[slot]
+            record.stream.synchronize()
             try:
-                yield results, evts, leases_by_ts
+                yield record
             finally:
                 # The yield above is the registration window.  This finally
                 # also protects generator close/early loop termination.
-                for lease in leases:
+                for lease in record.leases:
                     lease.wait_until_safe_to_reuse()
                 self._slots[slot] = None
 

--- a/psana/psana/gpu/gpu_stream.py
+++ b/psana/psana/gpu/gpu_stream.py
@@ -107,8 +107,15 @@ class EventPool:
         # This lookup happens after the caller has consumed the yielded
         # result.  In particular, on_gpu_view().__exit__ may have registered
         # its external-kernel completion event during that interval.
-        for lease in old.leases:
-            lease.wait_until_safe_to_reuse()
+        try:
+            for lease in old.leases:
+                lease.wait_until_safe_to_reuse()
+        except Exception:
+            # Leave the slot occupied because consumer completion was not
+            # confirmed, but release the in-progress latch so retirement can
+            # be retried instead of permanently locking the pool.
+            self._retiring = None
+            raise
 
         self._slots[old.slot_id] = None
         self._retiring = None

--- a/psana/psana/gpu/notes/gpu_memory_backpressure_and_async_join.md
+++ b/psana/psana/gpu/notes/gpu_memory_backpressure_and_async_join.md
@@ -79,8 +79,9 @@ Current reusable or persistent GPU allocations include:
 
 The slot buffers grow to their observed high-water sizes and generally do not
 shrink. `n_gpu_streams=2` therefore means at most two batches, not at most a
-specific number of GiB. `free_calib_bufs()` drops only calibrated-output
-references and is not a complete backpressure mechanism.
+specific number of GiB. The former `free_calib_bufs()` helper was removed: it
+dropped only calibrated-output references and was not a complete backpressure
+mechanism.
 
 ## Separate The Control Units
 
@@ -219,7 +220,7 @@ FREE
   -> READING
   -> COMPUTING
   -> RESULT_READY
-  -> GPU_CONSUMER or D2H_IN_FLIGHT
+  -> CONSUMER_IN_FLIGHT
   -> FREE
 ```
 
@@ -227,9 +228,8 @@ Relevant CUDA completion points include:
 
 ```text
 read_done
-calib_done
-downstream_done
-d2h_done
+result_ready
+consumer_done
 ```
 
 The final consumer returns an event or completion token. EventPool may recycle
@@ -238,9 +238,9 @@ the slot only after that token completes.
 For an asynchronous D2H on a separate stream:
 
 ```text
-calibration stream:  ... -> record calib_done
-copy stream:         wait calib_done -> D2H -> record d2h_done
-EventPool:           wait/query d2h_done before slot reuse
+producer stream:  ... -> record result_ready
+copy stream:      wait result_ready -> D2H -> record consumer_done
+EventPool:        wait/query consumer_done before slot reuse
 ```
 
 A `GPUResult` used directly by downstream GPU code also needs explicit lifetime

--- a/psana/psana/gpu/notes/join_operation.md
+++ b/psana/psana/gpu/notes/join_operation.md
@@ -379,11 +379,7 @@ array and copy:
 calib_saved = ctx.get('calib').on_cpu     # NumPy, independent
 
 # Option 2: Copy to separate GPU array (stays on GPU, independent)
-calib_saved = ctx.get('calib').on_gpu.copy()   # CuPy, independent
-
-# Option 3: call free_calib_bufs() to release slot buffers entirely,
-#            which falls back to dynamic allocation (no recycling).
-gpu_events_obj.free_calib_bufs()
+calib_saved = ctx.get('calib').on_gpu   # CuPy, independent
 ```
 
 ---
@@ -459,10 +455,9 @@ For GPU accumulators (CuPy arrays), this is a `arr.fill(0)` call.
 The `join()` function itself does not reset accumulators — the user
 controls this.
 
-If `free_calib_bufs()` is called at the checkpoint to reclaim GPU memory,
-any CuPy arrays derived from `calib_gpu` (views into the pre-allocated
-slot buffer) would become invalid.  The user must ensure their accumulator
-arrays are independent copies, not views.
+GPU accumulators retained across checkpoints must be independent allocations,
+not views into reusable EventPool slot buffers. Use `on_gpu` for an independent
+device copy or keep zero-copy `on_gpu_view()` work within its lease scope.
 
 ### 6. Checkpoint alignment with batch boundaries
 

--- a/psana/psana/gpu/scripts/gpu_multi_rank_smoke.py
+++ b/psana/psana/gpu/scripts/gpu_multi_rank_smoke.py
@@ -71,7 +71,8 @@ if _WORLD_RANK == 0:
     _ap.add_argument('--batch-size', type=int, default=10,
                      help='EB batch size in L1Accept events (default 10)')
     _ap.add_argument('--pool-depth', type=int, default=4,
-                     help='EventPool depth / n_gpu_streams (default 4)')
+                     help='EventPool depth / n_gpu_streams '
+                          '(smoke-test default 4; DataSource default 2)')
     _args = _ap.parse_args()
     _cfg = (_args.max_events, _args.batch_size, _args.pool_depth)
 else:

--- a/psana/psana/psexp/ds_base.py
+++ b/psana/psana/psexp/ds_base.py
@@ -60,8 +60,8 @@ class DsParms:
     # DataSource(gpu_det=['jungfrau', 'epix']).  When set, Run.events()
     # yields GpuEventContext objects instead of Event objects.
     gpu_det: object = None  # str | list[str] | None
-    n_gpu_streams: int = 2  # EventPool depth; 2 fully hides calib kernel behind I/O
-    gpu_d2h_chunk_size: int = 0  # GpuEvents internal D2H chunk; 0 = disabled (lazy per-call)
+    n_gpu_streams: int = 2  # EventPool execution-slot depth; 2 permits pipeline overlap
+    gpu_d2h_chunk_size: int = 0  # 0 disables automatic D2H; on_cpu does one cached blocking D2H
     gpu_memory_budget_gb: float = 0  # per-BD VRAM limit in GiB; 0 = auto (device_total / n_bd_ranks)
     # GPU-routed bigdata stream indices.  Populated from the Configure dgrams
     # already parsed by DgramManager.  Forwarded to EventBuilder so it can

--- a/psana/psana/tests/gpu/unit/test_core.py
+++ b/psana/psana/tests/gpu/unit/test_core.py
@@ -97,11 +97,18 @@ class _FakeFlushPool:
         pending, self.pending = self.pending, []
         for item in pending:
             self.yield_count += 1
-            # yield 3-tuple: (gpu_results_by_ts, cpu_evts, leases_by_ts)
-            if len(item) == 2:
-                yield item[0], item[1], {}
-            else:
+            if hasattr(item, "gpu_results_by_ts"):
                 yield item
+                continue
+            results, evts = item[:2]
+            leases = item[2] if len(item) > 2 else {}
+            yield SimpleNamespace(
+                gpu_results_by_ts=results,
+                cpu_evts=evts,
+                leases_by_ts=leases,
+                pending_d2h_by_ts={},
+                cpu_results_by_ts={},
+            )
 
 
 @pytest.fixture
@@ -149,10 +156,10 @@ def test_event_pool_retires_slot_before_reuse(monkeypatch):
     with pytest.raises(RuntimeError, match="before retirement finished"):
         pool.submit(None, None, ["event-1"], detectors)
 
-    results, events, leases_by_ts = pool.begin_retire_next()
-    assert results == {}
-    assert events == ["event-0"]
-    assert leases_by_ts == {}
+    record = pool.begin_retire_next()
+    assert record.gpu_results_by_ts == {}
+    assert record.cpu_evts == ["event-0"]
+    assert record.leases_by_ts == {}
     assert pool._streams[0].synchronize_calls == 1
     with pytest.raises(RuntimeError, match="before retirement finished"):
         pool.submit(None, None, ["event-1"], detectors)

--- a/psana/psana/tests/gpu/unit/test_core.py
+++ b/psana/psana/tests/gpu/unit/test_core.py
@@ -107,7 +107,7 @@ class _FakeFlushPool:
                 cpu_evts=evts,
                 leases_by_ts=leases,
                 pending_d2h_by_ts={},
-                cpu_results_by_ts={},
+                cached_cpu_results_by_ts={},
             )
 
 

--- a/psana/psana/tests/gpu/unit/test_core.py
+++ b/psana/psana/tests/gpu/unit/test_core.py
@@ -146,15 +146,18 @@ def test_event_pool_retires_slot_before_reuse(monkeypatch):
     detectors = {"jungfrau": (None, _FakeDetector())}
 
     pool.submit(None, None, ["event-0"], detectors)
-    with pytest.raises(RuntimeError, match="without retire_next"):
+    with pytest.raises(RuntimeError, match="before retirement finished"):
         pool.submit(None, None, ["event-1"], detectors)
 
-    results, events, leases_by_ts = pool.retire_next()
+    results, events, leases_by_ts = pool.begin_retire_next()
     assert results == {}
     assert events == ["event-0"]
     assert leases_by_ts == {}
     assert pool._streams[0].synchronize_calls == 1
+    with pytest.raises(RuntimeError, match="before retirement finished"):
+        pool.submit(None, None, ["event-1"], detectors)
 
+    pool.finish_retire_next()
     pool.submit(None, None, ["event-1"], detectors)
 
 

--- a/psana/psana/tests/gpu/unit/test_event_joiner.py
+++ b/psana/psana/tests/gpu/unit/test_event_joiner.py
@@ -196,7 +196,7 @@ class TestEventPoolLeases:
     def test_finish_retire_observes_consumer_registered_after_begin(self, monkeypatch):
         """A consumer registered while the result is exposed must be joined."""
         from psana.gpu.context import SlotLease
-        from psana.gpu.gpu_stream import EventPool
+        from psana.gpu.gpu_stream import EventPool, _EventSlot
 
         pool = EventPool(n=1)
         detectors = {}  # no detectors → no events, but leases_by_ts={}
@@ -206,7 +206,14 @@ class TestEventPoolLeases:
         calib_done = _FakeEvent()
         lease = SlotLease(calib_done)
         stream = pool._streams[0]
-        pool._slots[0] = ({}, [], stream, [lease], {})
+        pool._slots[0] = _EventSlot(
+            slot_id=0,
+            gpu_results_by_ts={},
+            cpu_evts=[],
+            stream=stream,
+            leases=[lease],
+            leases_by_ts={},
+        )
         pool._write_idx = 1  # pretend one batch was submitted
 
         assert not pending_d2h._synced
@@ -413,45 +420,62 @@ class TestPinnedCpu:
 
 
 class TestD2hPipeline:
-    """Tests for the internal GpuEvents._D2hPipeline class.
+    """Tests for eager slot-level scheduling in _D2hPipeline."""
 
-    With the lazy-sync design, contexts are yielded IMMEDIATELY after
-    D→H is issued.  GPUResult._pending_d2h carries the CUDA done-event;
-    on_cpu waits lazily at the call site.
-    """
+    def _make_record(self, fills=(1.0,), key="jungfrau.calib",
+                     n_segs=4, nrows=8, ncols=8):
+        from psana.gpu.context import SlotLease
+        from psana.gpu.gpu_stream import _EventSlot
 
-    def _make_ctx(self, fill=1.0, key="jungfrau.calib", n_segs=4, nrows=8, ncols=8):
-        from psana.gpu.context import GpuEventContext, SlotLease
-        from types import SimpleNamespace
-
-        arr = _make_arr(n_segs=n_segs, nrows=nrows, ncols=ncols, fill=fill)
-        calib = _FakeEvent()
-        lease = SlotLease(calib_done=calib)
-        fake_evt = SimpleNamespace(timestamp=int(fill * 100))
-        ctx = GpuEventContext(
-            evt=fake_evt,
-            gpu_results={key: arr},
-            leases={key: lease},
+        gpu_results_by_ts = {}
+        leases_by_ts = {}
+        cpu_evts = []
+        leases = []
+        for fill in fills:
+            ts = int(fill * 100)
+            evt = SimpleNamespace(timestamp=ts)
+            lease = SlotLease(calib_done=_FakeEvent())
+            gpu_results_by_ts[ts] = {
+                key: _make_arr(
+                    n_segs=n_segs,
+                    nrows=nrows,
+                    ncols=ncols,
+                    fill=fill,
+                )
+            }
+            leases_by_ts[ts] = {key: lease}
+            cpu_evts.append(evt)
+            leases.append(lease)
+        return _EventSlot(
+            slot_id=0,
+            gpu_results_by_ts=gpu_results_by_ts,
+            cpu_evts=cpu_evts,
+            stream=_FakeStream(),
+            leases=leases,
+            leases_by_ts=leases_by_ts,
         )
-        return ctx
 
-    def test_pipeline_yields_immediately(self):
-        """Checks that the generator does not hold events waiting for D→H
-        to complete.  Adds 2 events with chunk_size=2.  After the first
-        add() the chunk is not full so nothing is returned.  After the
-        second add() the chunk fires and both events are returned — before
-        the transfer has finished (because the fake done_event is not yet
-        polled)."""
+    @staticmethod
+    def _make_ctx(record, evt):
+        from psana.gpu.context import GpuEventContext
+
+        ts = evt.timestamp
+        return GpuEventContext(
+            evt=evt,
+            gpu_results=record.gpu_results_by_ts.get(ts, {}),
+            leases=record.leases_by_ts.get(ts, {}),
+            pending_d2h=record.pending_d2h_by_ts.get(ts, {}),
+            cpu_results=record.cpu_results_by_ts.get(ts, {}),
+        )
+
+    def test_pipeline_schedules_complete_slot_immediately(self):
+        """All results in a submitted slot receive host-result tokens."""
         from psana.gpu.gpu_events import _D2hPipeline
 
         pipe = _D2hPipeline(det_key="jungfrau.calib", chunk_size=2)
-        ctx0 = self._make_ctx(fill=1.0)
-        ctx1 = self._make_ctx(fill=2.0)
-
-        ready = pipe.add(ctx0)
-        assert ready == [], "should not yield before chunk is full"
-        ready = pipe.add(ctx1)
-        assert len(ready) == 2, "both contexts yielded after chunk filled"
+        record = self._make_record(fills=(1.0, 2.0))
+        pipe.schedule(record)
+        assert set(record.pending_d2h_by_ts) == {100, 200}
 
     def test_pipeline_sets_pending_d2h(self):
         """Checks that the lazy-sync token is attached before yielding.
@@ -461,14 +485,11 @@ class TestD2hPipeline:
         from psana.gpu.gpu_events import _D2hPipeline
 
         pipe = _D2hPipeline(det_key="jungfrau.calib", chunk_size=2)
-        ctx0 = self._make_ctx(fill=1.0)
-        ctx1 = self._make_ctx(fill=2.0)
-        for ctx in [ctx0, ctx1]:
-            pipe.add(ctx)
-        # After yielding, the GPUResult in the cache must have _pending_d2h.
-        for ctx in [ctx0, ctx1]:
-            result = ctx._cache.get("jungfrau.calib")
-            assert result is not None
+        record = self._make_record(fills=(1.0, 2.0))
+        pipe.schedule(record)
+        for evt in record.cpu_evts:
+            ctx = self._make_ctx(record, evt)
+            result = ctx.get("jungfrau.calib")
             assert result._pending_d2h is not None, "_pending_d2h must be set so on_cpu can sync lazily"
 
     def test_on_cpu_returns_correct_data(self):
@@ -482,51 +503,31 @@ class TestD2hPipeline:
 
         pipe = _D2hPipeline(det_key="jungfrau.calib", chunk_size=2)
         fills = [3.0, 7.0]
-        ctxs = [self._make_ctx(fill=v) for v in fills]
-        ready = []
-        for ctx in ctxs:
-            ready.extend(pipe.add(ctx))
-        for ctx, expected in zip(ready, fills):
+        record = self._make_record(fills=fills)
+        pipe.schedule(record)
+        for evt, expected in zip(record.cpu_evts, fills):
+            ctx = self._make_ctx(record, evt)
             result = ctx.get("jungfrau.calib")
             np.testing.assert_allclose(result.on_cpu, expected)
 
-    def test_pipeline_flush_partial(self):
-        """Checks the batch-boundary drain path.  Adds 1 event to a
-        pipeline with chunk_size=3 — the chunk is not full so add()
-        returns nothing.  Calls flush() and checks the stranded event is
-        returned.  Without this flush, events whose count does not reach
-        chunk_size (e.g. the last batch of a run) would never be
-        yielded to the user."""
+    def test_pipeline_schedules_partial_chunk_immediately(self):
+        """A slot smaller than chunk_size is armed without a later flush."""
         from psana.gpu.gpu_events import _D2hPipeline
 
         pipe = _D2hPipeline(det_key="jungfrau.calib", chunk_size=3)
-        ctx = self._make_ctx(fill=1.0)
-        assert pipe.add(ctx) == [], "no yield before chunk_size reached"
-        ready = pipe.flush()
-        assert len(ready) == 1
-        # The context is yielded with _pending_d2h set.
-        result = ready[0].get("jungfrau.calib")
-        assert result._pending_d2h is not None or result._pinned_cpu is not None
+        record = self._make_record()
+        pipe.schedule(record)
+        assert record.pending_d2h_by_ts[100]["jungfrau.calib"] is not None
 
     def test_pipeline_unknown_key_passthrough(self):
-        """Checks that the pipeline does not buffer events it has no data
-        for.  A context whose gpu_results dict does not contain the
-        pipeline's det_key (e.g. a BeginStep transition or a detector
-        that was absent in this event) must be returned immediately by
-        add() without entering the chunk buffer."""
+        """A slot without the configured result key is left unchanged."""
         from psana.gpu.gpu_events import _D2hPipeline
-        from psana.gpu.context import GpuEventContext
-        from types import SimpleNamespace
 
         pipe = _D2hPipeline(det_key="jungfrau.calib", chunk_size=2)
-        fake_evt = SimpleNamespace(timestamp=0)
-        ctx = GpuEventContext(
-            evt=fake_evt,
-            gpu_results={},  # no calib key
-            leases={},
-        )
-        ready = pipe.add(ctx)
-        assert ready == [ctx], "context without matching key must pass through"
+        record = self._make_record(key="jungfrau.raw")
+        pipe.schedule(record)
+        assert record.pending_d2h_by_ts == {}
+        assert record.cpu_results_by_ts == {}
 
     def test_calib_done_waited_before_d2h(self):
         """Checks the ordering guarantee between calibration and transfer.
@@ -538,61 +539,38 @@ class TestD2hPipeline:
         from psana.gpu.gpu_events import _D2hPipeline
 
         pipe = _D2hPipeline(det_key="jungfrau.calib", chunk_size=1)
-        ctx = self._make_ctx(fill=5.0)
-        pipe.add(ctx)
-        calib = ctx._leases["jungfrau.calib"].calib_done
+        record = self._make_record(fills=(5.0,))
+        pipe.schedule(record)
+        calib = record.leases_by_ts[500]["jungfrau.calib"].calib_done
         assert calib in pipe._d2h_stream.wait_events, "D→H stream must call wait_event(calib_done) before memcpyAsync"
 
-    def test_get_free_slot_returns_none_when_all_slots_busy(self):
-        """Non-blocking fallback: _flush_chunk returns events without
-        _pending_d2h when all pinned slots are occupied.
-
-        This prevents the generator from deadlocking when the user
-        accumulates contexts before calling on_cpu (e.g. list(run.events())).
-
-        Sequence:
-          1. chunk_size=1 — each add() flushes immediately.
-          2. Add two events without calling on_cpu — both slots are now
-             claimed; _available queue is empty.
-          3. Add a third event.  _get_free_slot() must return None
-             (SimpleQueue.get_nowait() raises Empty), so the event is
-             yielded WITHOUT _pending_d2h (sync fallback path).
-          4. Verify ctx2's GPUResult has _pending_d2h=None.
-          5. Now call on_cpu for ctx0 — dec_ref() returns slot to queue.
-          6. Add a fourth event — slot available, async D→H resumes.
-        """
+    def test_no_free_pinned_slot_materializes_safe_cpu_fallback(self):
+        """Pinned exhaustion caches CPU data before device-slot reuse."""
         from psana.gpu.gpu_events import _D2hPipeline
 
         pipe = _D2hPipeline(det_key="jungfrau.calib", chunk_size=1)
 
-        # Warm up: two events — both slots claimed; _available queue empty.
-        ctx0 = self._make_ctx(fill=1.0)
-        ctx1 = self._make_ctx(fill=2.0)
-        pipe.add(ctx0)
-        pipe.add(ctx1)
+        record0 = self._make_record(fills=(1.0,))
+        record1 = self._make_record(fills=(2.0,))
+        pipe.schedule(record0)
+        pipe.schedule(record1)
         assert pipe._available.empty(), "both slots should be claimed"
 
-        # Third event: queue empty → sync fallback (no _pending_d2h).
-        ctx2 = self._make_ctx(fill=3.0)
-        ready = pipe.add(ctx2)
-        assert len(ready) == 1, "ctx2 should be yielded immediately via sync fallback"
-        result2 = ready[0].get("jungfrau.calib")
-        assert result2._pending_d2h is None, (
-            "sync fallback should not attach _pending_d2h"
-        )
+        record2 = self._make_record(fills=(3.0,))
+        pipe.schedule(record2)
+        ctx2 = self._make_ctx(record2, record2.cpu_evts[0])
+        result2 = ctx2.get("jungfrau.calib")
+        assert result2._pending_d2h is None
+        np.testing.assert_allclose(result2.on_cpu, 3.0)
 
         # Free a slot: dec_ref() puts the slot back into _available.
-        ctx0.get("jungfrau.calib").on_cpu
+        self._make_ctx(record0, record0.cpu_evts[0]).get("jungfrau.calib").on_cpu
         assert not pipe._available.empty(), "slot should be back in the free queue"
 
         # Fourth event: slot available → async D→H resumes.
-        ctx3 = self._make_ctx(fill=4.0)
-        ready = pipe.add(ctx3)
-        assert len(ready) == 1, "ctx3 should be yielded"
-        result3 = ready[0].get("jungfrau.calib")
-        assert result3._pending_d2h is not None, (
-            "async D→H should resume once a slot is returned to the queue"
-        )
+        record3 = self._make_record(fills=(4.0,))
+        pipe.schedule(record3)
+        assert record3.pending_d2h_by_ts[400]["jungfrau.calib"] is not None
 
     def test_dec_ref_race_lock_prevents_lost_update(self):
         """_refs_lock ensures that concurrent dec_ref() calls produce the
@@ -611,10 +589,10 @@ class TestD2hPipeline:
 
         # Prime: two events with chunk_size=1 → each flushes into its own slot.
         # After both adds the _available queue must be empty (_refs=1 each).
-        ctx0 = self._make_ctx(fill=1.0)
-        ctx1 = self._make_ctx(fill=2.0)
-        pipe.add(ctx0)
-        pipe.add(ctx1)
+        record0 = self._make_record(fills=(1.0,))
+        record1 = self._make_record(fills=(2.0,))
+        pipe.schedule(record0)
+        pipe.schedule(record1)
         assert pipe._available.empty(), "both slots should be claimed (queue empty)"
 
         # Pick the slot that ctx0 is using — it has _refs=1.

--- a/psana/psana/tests/gpu/unit/test_event_joiner.py
+++ b/psana/psana/tests/gpu/unit/test_event_joiner.py
@@ -191,9 +191,8 @@ class TestSlotLease:
 
 
 class TestEventPoolLeases:
-    def test_retire_next_waits_for_d2h_before_recycle(self, monkeypatch):
-        """EventPool.retire_next() must call synchronize() on every registered
-        D→H done-event before synchronising the calibration stream."""
+    def test_finish_retire_observes_consumer_registered_after_begin(self, monkeypatch):
+        """A consumer registered while the result is exposed must be joined."""
         from psana.gpu.context import SlotLease
         from psana.gpu.gpu_stream import EventPool
 
@@ -203,17 +202,20 @@ class TestEventPoolLeases:
         # Manually inject a slot that has a lease with a pending D→H.
         pending_d2h = _PendingEvent()
         calib_done = _FakeEvent()
-        fake_arr = _make_arr()
         lease = SlotLease(calib_done)
-        lease.register_d2h_done(pending_d2h)
-
         stream = pool._streams[0]
         pool._slots[0] = ({}, [], stream, [lease], {})
         pool._write_idx = 1  # pretend one batch was submitted
 
         assert not pending_d2h._synced
-        pool.retire_next()
-        assert pending_d2h._synced, "retire_next() must synchronise D→H before recycling the slot"
+        pool.begin_retire_next()
+        assert pool._slots[0] is not None, "begin must retain slot ownership"
+
+        # Models on_gpu_view().__exit__ running after the context was yielded.
+        lease.register_d2h_done(pending_d2h)
+        pool.finish_retire_next()
+        assert pending_d2h._synced, "finish must join the late-registered consumer"
+        assert pool._slots[0] is None
 
 
 # ===========================================================================
@@ -254,7 +256,7 @@ class TestOnGpuAndView:
 
     def test_on_gpu_view_records_done_event_on_exit(self):
         """__exit__ must record a done-event on the provided stream so
-        EventPool.retire_next() knows when the slot is safe to recycle."""
+        EventPool.finish_retire_next() knows when the slot is safe to recycle."""
         from psana.gpu.context import GPUResult, SlotLease
 
         arr = _make_arr()
@@ -278,7 +280,7 @@ class TestOnGpuAndView:
         with result.on_gpu_view(_FakeStream()):
             pass
         lease.wait_until_safe_to_reuse()   # must not raise
-        assert lease._d2h_done._synced, "retire_next must synchronize the done event"
+        assert lease._d2h_done._synced, "final retirement must synchronize the done event"
 
     def test_on_gpu_view_raises_without_lease(self):
         """on_gpu_view must raise RuntimeError when the GPUResult has no lease."""

--- a/psana/psana/tests/gpu/unit/test_event_joiner.py
+++ b/psana/psana/tests/gpu/unit/test_event_joiner.py
@@ -117,6 +117,7 @@ class _FakeGPUArr:
 
     def __init__(self, data: np.ndarray):
         self._np = np.ascontiguousarray(data, dtype=np.float32)
+        self.get_calls = 0
         self.shape = self._np.shape
         self.dtype = self._np.dtype
         self.nbytes = self._np.nbytes
@@ -126,6 +127,7 @@ class _FakeGPUArr:
         return _FakeGPUArr(self._np.copy())
 
     def get(self) -> np.ndarray:
+        self.get_calls += 1
         return self._np.copy()
 
 
@@ -370,6 +372,21 @@ class TestPinnedCpu:
         copy = result.on_gpu
         assert copy is not arr, "on_gpu must return a copy, not the original"
         np.testing.assert_allclose(copy._np, arr._np)
+
+    def test_sync_fallback_caches_first_d2h_result(self):
+        """Repeated on_cpu access must not read a reused GPU slot again."""
+        from psana.gpu.context import GPUResult
+
+        arr = _make_arr(fill=3.0)
+        result = GPUResult(arr_gpu=arr)
+
+        first = result.on_cpu
+        arr._np.fill(9.0)  # model the execution slot being overwritten
+        second = result.on_cpu
+
+        assert first is second
+        assert arr.get_calls == 1
+        np.testing.assert_allclose(second, 3.0)
 
     def test_gpu_event_context_get_returns_gpu_result(self):
         """GpuEventContext.get() must return a GPUResult with the correct array."""

--- a/psana/psana/tests/gpu/unit/test_gpu_result_lifetime.py
+++ b/psana/psana/tests/gpu/unit/test_gpu_result_lifetime.py
@@ -64,6 +64,18 @@ class _PendingEvent(_FakeEvent):
         pass  # recording does NOT auto-mark done
 
 
+class _FailOnceLease:
+    """Lease-like test double whose first consumer synchronization fails."""
+
+    def __init__(self):
+        self.wait_calls = 0
+
+    def wait_until_safe_to_reuse(self):
+        self.wait_calls += 1
+        if self.wait_calls == 1:
+            raise RuntimeError("consumer synchronization failed")
+
+
 class _FakeStream:
     """Fake cp.cuda.Stream."""
 
@@ -224,6 +236,35 @@ class TestEventPoolLeases:
         lease.register_consumer_done(pending_d2h)
         pool.finish_retire_next()
         assert pending_d2h._synced, "finish must join the late-registered consumer"
+        assert pool._slots[0] is None
+
+    def test_finish_retire_can_retry_after_consumer_sync_error(self):
+        """A failed join keeps the slot protected but does not lock retirement."""
+        from psana.gpu.gpu_stream import EventPool, _EventSlot
+
+        pool = EventPool(n=1)
+        lease = _FailOnceLease()
+        record = _EventSlot(
+            slot_id=0,
+            gpu_results_by_ts={},
+            cpu_evts=[],
+            stream=pool._streams[0],
+            leases=[lease],
+            leases_by_ts={},
+        )
+        pool._slots[0] = record
+        pool._write_idx = 1
+
+        pool.begin_retire_next()
+        with pytest.raises(RuntimeError, match="consumer synchronization failed"):
+            pool.finish_retire_next()
+
+        assert pool._retiring is None
+        assert pool._slots[0] is record, "failed consumer must keep slot protected"
+
+        assert pool.begin_retire_next() is record
+        pool.finish_retire_next()
+        assert lease.wait_calls == 2
         assert pool._slots[0] is None
 
 
@@ -627,3 +668,25 @@ class TestD2hPipeline:
             f"slot should be returned to queue exactly once, got {len(returned)}"
         )
         assert returned[0] is slot, "the returned object should be the slot itself"
+
+    def test_dec_ref_after_zero_does_not_queue_slot_twice(self):
+        """An extra release is harmless and cannot duplicate a free slot."""
+        from queue import SimpleQueue
+        from psana.gpu.gpu_events import _PinnedSlot
+
+        available = SimpleQueue()
+        slot = _PinnedSlot(
+            max_segs=1,
+            nrows=1,
+            ncols=1,
+            chunk_size=1,
+            available=available,
+        )
+        slot.claim(1)
+
+        slot.dec_ref()
+        slot.dec_ref()
+
+        assert slot._refs == 0
+        assert available.get_nowait() is slot
+        assert available.empty(), "slot must be returned exactly once"

--- a/psana/psana/tests/gpu/unit/test_gpu_result_lifetime.py
+++ b/psana/psana/tests/gpu/unit/test_gpu_result_lifetime.py
@@ -156,8 +156,8 @@ class TestSlotLease:
         from psana.gpu.context import SlotLease
 
         event = _FakeEvent()
-        lease = SlotLease(calib_done=event)
-        # No register_d2h_done — should be a no-op
+        lease = SlotLease(result_ready=event)
+        # No register_consumer_done — should be a no-op
         lease.wait_until_safe_to_reuse()  # must not raise or hang
 
     def test_d2h_registered_calls_synchronize(self):
@@ -166,8 +166,8 @@ class TestSlotLease:
 
         calib = _FakeEvent()
         d2h = _FakeEvent()
-        lease = SlotLease(calib_done=calib)
-        lease.register_d2h_done(d2h)
+        lease = SlotLease(result_ready=calib)
+        lease.register_consumer_done(d2h)
         lease.wait_until_safe_to_reuse()
         assert d2h._sync_calls == 1
 
@@ -178,8 +178,8 @@ class TestSlotLease:
 
         calib = _FakeEvent()
         pending = _PendingEvent()  # starts not done
-        lease = SlotLease(calib_done=calib)
-        lease.register_d2h_done(pending)
+        lease = SlotLease(result_ready=calib)
+        lease.register_consumer_done(pending)
 
         assert not pending.done  # not done yet
         # Calling wait_until_safe_to_reuse() must call synchronize()
@@ -203,8 +203,8 @@ class TestEventPoolLeases:
 
         # Manually inject a slot that has a lease with a pending D→H.
         pending_d2h = _PendingEvent()
-        calib_done = _FakeEvent()
-        lease = SlotLease(calib_done)
+        result_ready = _FakeEvent()
+        lease = SlotLease(result_ready)
         stream = pool._streams[0]
         pool._slots[0] = _EventSlot(
             slot_id=0,
@@ -221,14 +221,14 @@ class TestEventPoolLeases:
         assert pool._slots[0] is not None, "begin must retain slot ownership"
 
         # Models on_gpu_view().__exit__ running after the context was yielded.
-        lease.register_d2h_done(pending_d2h)
+        lease.register_consumer_done(pending_d2h)
         pool.finish_retire_next()
         assert pending_d2h._synced, "finish must join the late-registered consumer"
         assert pool._slots[0] is None
 
 
 # ===========================================================================
-# GPUResult._pinned_cpu / GpuEventContext._pinned_results tests
+# GPUResult._cpu_cache / GpuEventContext._cached_cpu_results tests
 # ===========================================================================
 
 
@@ -258,7 +258,7 @@ class TestOnGpuAndView:
         from psana.gpu.context import GPUResult, SlotLease
 
         arr = _make_arr()
-        lease = SlotLease(calib_done=_FakeEvent())
+        lease = SlotLease(result_ready=_FakeEvent())
         result = GPUResult(arr_gpu=arr, lease=lease)
         with result.on_gpu_view(_FakeStream()) as view:
             assert view is arr, "on_gpu_view must yield the original array, not a copy"
@@ -269,13 +269,13 @@ class TestOnGpuAndView:
         from psana.gpu.context import GPUResult, SlotLease
 
         arr = _make_arr()
-        lease = SlotLease(calib_done=_FakeEvent())
+        lease = SlotLease(result_ready=_FakeEvent())
         result = GPUResult(arr_gpu=arr, lease=lease)
         stream = _FakeStream()
         with result.on_gpu_view(stream):
             pass
-        assert lease._d2h_done is not None, "__exit__ must register a done event on the lease"
-        assert lease._d2h_done in stream.recorded_events, \
+        assert lease._consumer_done is not None, "__exit__ must register a done event on the lease"
+        assert lease._consumer_done in stream.recorded_events, \
             "done event must be recorded on the provided stream"
 
     def test_on_gpu_view_retire_safe_after_context_exit(self):
@@ -284,12 +284,12 @@ class TestOnGpuAndView:
         from psana.gpu.context import GPUResult, SlotLease
 
         arr = _make_arr()
-        lease = SlotLease(calib_done=_FakeEvent())
+        lease = SlotLease(result_ready=_FakeEvent())
         result = GPUResult(arr_gpu=arr, lease=lease)
         with result.on_gpu_view(_FakeStream()):
             pass
         lease.wait_until_safe_to_reuse()   # must not raise
-        assert lease._d2h_done._synced, "final retirement must synchronize the done event"
+        assert lease._consumer_done._synced, "final retirement must synchronize the done event"
 
     def test_on_gpu_view_raises_without_lease(self):
         """on_gpu_view must raise RuntimeError when the GPUResult has no lease."""
@@ -352,30 +352,30 @@ class TestGpuBudget:
         assert b.committed() == 0
 
 
-class TestPinnedCpu:
-    """Tests for the GpuEvents internal D→H path where _pinned_cpu is set
-    on GPUResult and _pinned_results is set on GpuEventContext before the
+class TestCpuCache:
+    """Tests for the GpuEvents internal D→H path where _cpu_cache is set
+    on GPUResult and _cached_cpu_results is set on GpuEventContext before the
     context is yielded to the user."""
 
-    def test_on_cpu_returns_pinned_immediately(self):
-        """When _pinned_cpu is set, on_cpu must return it without touching _arr."""
+    def test_on_cpu_returns_cached_result_immediately(self):
+        """When _cpu_cache is set, on_cpu must return it without touching _arr."""
         from psana.gpu.context import GPUResult
 
-        pinned = np.ones((4, 8, 8), dtype=np.float32) * 7.0
+        cached = np.ones((4, 8, 8), dtype=np.float32) * 7.0
         result = GPUResult(arr_gpu=None)
-        result._pinned_cpu = pinned   # set directly (as _D2hPipeline does via on_cpu)
+        result._cpu_cache = cached
         out = result.on_cpu
-        np.testing.assert_array_equal(out, pinned)
+        np.testing.assert_array_equal(out, cached)
 
-    def test_on_gpu_unaffected_by_pinned_cpu(self):
-        """on_gpu returns a copy of _arr even when pinned_cpu is set.
-        The copy must have the same values as _arr, not pinned_cpu."""
+    def test_on_gpu_unaffected_by_cpu_cache(self):
+        """on_gpu returns a copy of _arr even when the CPU cache is set.
+        The copy must have the same values as _arr, not the cached result."""
         from psana.gpu.context import GPUResult
 
         arr = _make_arr(fill=3.0)
-        pinned = np.zeros((4, 8, 8), dtype=np.float32)
+        cached = np.zeros((4, 8, 8), dtype=np.float32)
         result = GPUResult(arr_gpu=arr)
-        result._pinned_cpu = pinned
+        result._cpu_cache = cached
         copy = result.on_gpu
         assert copy is not arr, "on_gpu must return a copy, not the original"
         np.testing.assert_allclose(copy._np, arr._np)
@@ -434,7 +434,7 @@ class TestD2hPipeline:
         for fill in fills:
             ts = int(fill * 100)
             evt = SimpleNamespace(timestamp=ts)
-            lease = SlotLease(calib_done=_FakeEvent())
+            lease = SlotLease(result_ready=_FakeEvent())
             gpu_results_by_ts[ts] = {
                 key: _make_arr(
                     n_segs=n_segs,
@@ -465,7 +465,7 @@ class TestD2hPipeline:
             gpu_results=record.gpu_results_by_ts.get(ts, {}),
             leases=record.leases_by_ts.get(ts, {}),
             pending_d2h=record.pending_d2h_by_ts.get(ts, {}),
-            cpu_results=record.cpu_results_by_ts.get(ts, {}),
+            cached_cpu_results=record.cached_cpu_results_by_ts.get(ts, {}),
         )
 
     def test_pipeline_schedules_complete_slot_immediately(self):
@@ -527,12 +527,12 @@ class TestD2hPipeline:
         record = self._make_record(key="jungfrau.raw")
         pipe.schedule(record)
         assert record.pending_d2h_by_ts == {}
-        assert record.cpu_results_by_ts == {}
+        assert record.cached_cpu_results_by_ts == {}
 
-    def test_calib_done_waited_before_d2h(self):
+    def test_result_ready_waited_before_d2h(self):
         """Checks the ordering guarantee between calibration and transfer.
         After adding one event, inspects the D→H stream's wait_events
-        list and confirms that the calib_done CUDA event from the slot
+        list and confirms that the result_ready CUDA event from the slot
         lease appears in it.  This proves the memcpy cannot start until
         the calibration kernel has finished writing to the slot buffer —
         reading stale data would cause silent correctness errors."""
@@ -541,8 +541,8 @@ class TestD2hPipeline:
         pipe = _D2hPipeline(det_key="jungfrau.calib", chunk_size=1)
         record = self._make_record(fills=(5.0,))
         pipe.schedule(record)
-        calib = record.leases_by_ts[500]["jungfrau.calib"].calib_done
-        assert calib in pipe._d2h_stream.wait_events, "D→H stream must call wait_event(calib_done) before memcpyAsync"
+        calib = record.leases_by_ts[500]["jungfrau.calib"].result_ready
+        assert calib in pipe._d2h_stream.wait_events, "D→H stream must call wait_event(result_ready) before memcpyAsync"
 
     def test_no_free_pinned_slot_materializes_safe_cpu_fallback(self):
         """Pinned exhaustion caches CPU data before device-slot reuse."""


### PR DESCRIPTION
## Summary

I started by profiling the existing `psana2-gpu-d2h-pipeline` branch with ten
Jungfrau events, using `pool_depth` values of 1 and 2 and
`gpu_d2h_chunk_size` values of 0 and 2.

This exposed two slot-lifetime and scheduling problems:

1. A GPU execution slot could be retired before an external GPU consumer
   registered its completion event.
2. Automatic D2H scheduling and replacement H2D submission depended too
   heavily on later generator advancement, which prevented the configured pool
   depth from providing sustained overlap.

This PR fixes the slot-lifetime ordering, separates automatic-D2H delivery from
external GPU consumption, and allows multiple protected pipelines to overlap.

## 1. Protect execution slots until external consumers complete

The existing implementation could retire a GPU slot before user code
registered the CUDA kernel consuming that slot.

The new diagnostic script,
[`gpu_slot_overwrite_repro.py`](https://github.com/slac-lcls/lcls2/commit/872739d4e0c8cbf045130f3826169e34f19344cb#diff-fd49b3a17e6bf28355c272c5a3e123d43499cc3fd1e02814bc7f75288a4775dc),
demonstrates the race. In the affected implementation, a delayed kernel
consuming event 0 could observe the same slot after it had been overwritten by
event 1.

Slot retirement is now divided into two phases.

### `begin_retire_next()`

This phase:

- Synchronizes the producer stream so the slot's result is ready.
- Marks the slot as retiring.
- Exposes the result and its leases.
- Keeps the slot conceptually occupied, preventing reuse.

### `finish_retire_next()`

After user code has had an opportunity to launch work and register a
consumer-completion event, this phase:

- Waits for every registered terminal consumer.
- Applies backpressure while a consumer is still using the slot.
- Releases the slot only after all consumer-completion events have finished.

The external-consumer sequence is therefore:

```text
H2D
  -> calibration
  -> yield slot-backed result
  -> user launches downstream GPU work
  -> register consumer-completion event
  -> wait for consumer
  -> release slot
```

This creates a conservative ownership chain within each slot. The stages may
use different CUDA streams, but a new generation cannot reuse the same slot
until its current terminal consumer completes.

Concurrency is introduced by increasing `pool_depth`, which provides multiple
independently protected execution pipelines.

## 2. Schedule automatic D2H eagerly and issue replacement H2D before CPU delivery

After protecting slot retirement, I expected `pool_depth=2` to allow two
pipelines to overlap. Initially, this did not happen consistently because
automatic D2H was scheduled only when the result entered the retirement/yield
path, and retirement itself was triggered by a later incoming subbatch
requesting the slot.

Automatic D2H is now scheduled immediately after the slot is submitted:

```text
producer stream:
    calibration/routing -> record result-ready event

D2H stream:
    wait for result-ready event -> D2H -> record D2H-done event
```

Result delivery remains separate from D2H scheduling. The implementation now
has two retirement policies.

### Automatic D2H: `gpu_d2h_chunk_size > 0`

```text
schedule D2H immediately after slot submission

when the slot is needed again:
    wait for outgoing D2H
    -> release slot
    -> issue replacement H2D
    -> yield host-backed result
```

Before releasing the slot early, the implementation verifies that every
exposed result has either:

- A pending pinned-host D2H token, or
- An independent cached CPU fallback.

The yielded context is then explicitly host-only. It does not retain a stale
view into the released device slot. Calling `on_gpu` or `on_gpu_view` on such a
result produces a clear error directing GPU consumers to use
`gpu_d2h_chunk_size=0`.

### External GPU consumer: `gpu_d2h_chunk_size = 0`

```text
yield slot-backed GPU result
    -> user registers consumer-completion event
    -> finish retirement
    -> release slot
    -> issue replacement H2D
```

This preserves the registration window required by `on_gpu_view()` and
downstream GPU kernels.

- Stores pending D2H and cached CPU results on an explicit execution-slot
  record.
- Keeps pinned-buffer lifetime separate from execution-slot lifetime.
- Materializes an independent CPU result before device-slot reuse if every
  pinned slot is occupied.
- Tracks the single pre-issued KvikIO read and drains it before shutdown if
  iteration stops early.

## 3. Cache synchronous `on_cpu()` results

For `gpu_d2h_chunk_size=0`, the first `on_cpu()` call performs a blocking
`arr.get()`.

That result is now cached before being returned:

```python
self._cpu_cache = self._arr.get()
return self._cpu_cache
```

Subsequent `on_cpu()` calls return the same independent CPU result without
issuing another D2H or accessing a GPU slot that may already contain a newer
event.

## Validation

The branch was rebuilt successfully, and the GPU unit suite passes:

```text
60 passed
```

The slot-overwrite diagnostic can be run against this branch with:

```bash
mpirun -n 3 \
  python -u psana/psana/debugtools/gpu_slot_overwrite_repro.py \
    --exp mfx100848724 \
    --run 51 \
    --dir /sdf/data/lcls/ds/prj/public01/xtc \
    --expect safe \
    --log-level WARNING
```

## Nsight Systems reproduction

Run the following from the checked-out PR branch after building it and
activating the psana/CuPy environment on a GPU node.

The command assumes `nsys` is on `PATH`. If it is installed elsewhere, set
`PSANA_NSYS_BIN` to its full path.

```bash
PSANA_NSYS_BIN="${PSANA_NSYS_BIN:-nsys}"
PSANA_PROFILE_DIR="${PSANA_PROFILE_DIR:-$HOME/tmp/psana2-gpu/async-d2h}"

mkdir -p "$PSANA_PROFILE_DIR"
command -v "$PSANA_NSYS_BIN"

mpirun -n 3 \
  "$PSANA_NSYS_BIN" profile \
    --trace=cuda,nvtx,osrt \
    --sample=none \
    --cuda-memory-usage=true \
    --force-overwrite=true \
    -o "$PSANA_PROFILE_DIR/preyield_pd2_rank%q{OMPI_COMM_WORLD_RANK}" \
  python -u psana/psana/debugtools/ds_count_events.py \
    --exp mfx100848724 \
    --run 51 \
    --dir /sdf/data/lcls/ds/prj/public01/xtc \
    --gpu_det jungfrau \
    --gpu_pool_depth 2 \
    --gpu_d2h_chunk_size 2 \
    --gpu_d2h_interval 1 \
    --batch_size 1 \
    --max_events 10 \
    --print_interval 100 \
    --log_level WARNING
```

The BigData/GPU process is rank 2:

```text
$PSANA_PROFILE_DIR/preyield_pd2_rank2.nsys-rep
```

In the CUDA hardware rows, expect to see:

- KvikIO fallback H2D copies for each event.
- Jungfrau calibration kernels alternating between the two execution slots.
- One automatic D2H per event.
- D2H for one pipeline overlapping H2D for the other pipeline.

In my ten-event run, 8 of the 9 possible D2H-to-next-H2D pairs overlapped.
There were seven additional overlaps after the first pair; the only missed
pair was separated by approximately 0.645 ms.

This demonstrates the intended model:

```text
slot 0: H2D0 -> calib0 -> D2H0 -> release -> H2D2 -> ...
slot 1: H2D1 -> calib1 -> D2H1 -> release -> H2D3 -> ...
```

Each slot remains protected through its terminal consumer, while multiple
slots allow the pipelines to execute concurrently.
