### PR TITLE
Fix dmaCount comparison and accomodate low values

### DIFF
--- a/psdaq/drp/BldDetector.cc
+++ b/psdaq/drp/BldDetector.cc
@@ -690,7 +690,7 @@ private:
 
 
 Pgp::Pgp(Parameters& para, DrpBase& drp, Detector* det) :
-    PgpReader(para, drp.pool, MAX_RET_CNT_C, 32),
+    PgpReader(para, drp.pool, std::min(MAX_RET_CNT_C, drp.pool.dmaCount()), 32),
     m_para(para), m_drp(drp), m_det(det),
     m_config(0), m_terminate(false), m_running(false),
     m_available(0), m_current(0), m_nDmaRet(0)

--- a/psdaq/drp/BldDetector.hh
+++ b/psdaq/drp/BldDetector.hh
@@ -152,7 +152,7 @@ private:
     Parameters&                                m_para;
     DrpBase&                                   m_drp;
     Detector*                                  m_det;
-    static const int MAX_RET_CNT_C = 100;
+    static const unsigned MAX_RET_CNT_C = 100;
     std::vector<std::shared_ptr<BldFactory> >  m_config;
     std::atomic<bool>                          m_terminate;
     bool                                       m_running;

--- a/psdaq/drp/BldDetectorSlow.cc
+++ b/psdaq/drp/BldDetectorSlow.cc
@@ -486,7 +486,7 @@ public:
 
 
 Pgp::Pgp(Parameters& para, DrpBase& drp, Detector* det) :
-    PgpReader(para, drp.pool, MAX_RET_CNT_C, 32),
+    PgpReader(para, drp.pool, std::min(MAX_RET_CNT_C, drp.pool.dmaCount()), 32),
     m_para(para), m_drp(drp), m_det(det),
     m_config(0), m_terminate(false), m_running(false),
     m_available(0), m_current(0), m_next(0), m_nDmaRet(0)

--- a/psdaq/drp/DrpBase.cc
+++ b/psdaq/drp/DrpBase.cc
@@ -464,8 +464,7 @@ PgpReader::PgpReader(const Parameters& para, MemPool& pool, unsigned maxRetCnt, 
     dmaErrors     (maxRetCnt),
     m_lastComplete(0),
     m_lastTid     (TransitionId::Unconfigure),
-    m_dmaIndices  (maxRetCnt),
-    m_dmaRetCnt   (dmaFreeCnt),
+    m_dmaIndices  (dmaFreeCnt),
     m_count       (0),
     m_dmaBytes    (0),
     m_dmaSize     (0),
@@ -763,7 +762,7 @@ void PgpReader::freeDma(PGPEvent* event)
             auto idx = event->buffers[i].index;
             if (idx < m_pool.dmaCount()) [[likely]] {
                 m_dmaIndices[m_count++] = idx;
-                if (m_count >= m_dmaRetCnt) {
+                if (m_count == m_dmaIndices.size()) {
                     // Return buffers.  An index could be reused as soon as dmaRetIndexes() completes
                     if (!m_pool.freeDma(m_count, m_dmaIndices.data())) {
                         m_count = 0;    // Reset only on success

--- a/psdaq/drp/DrpBase.hh
+++ b/psdaq/drp/DrpBase.hh
@@ -190,7 +190,6 @@ protected:
     XtcData::TransitionId::Value m_lastTid;
     uint32_t m_lastData[6];
     std::vector<uint32_t> m_dmaIndices;
-    unsigned m_dmaRetCnt;
     unsigned m_count;
     uint64_t m_dmaBytes;
     uint64_t m_dmaSize;

--- a/psdaq/drp/PGPDetector.cc
+++ b/psdaq/drp/PGPDetector.cc
@@ -305,8 +305,8 @@ void workerFunc(const Parameters& para, DrpBase& drp, Detector& det,
 // ---
 
 Pgp::Pgp(const Parameters& para, MemPool& pool, Detector& det, PGPDrp& drp) :
-   PgpReader(para, pool, MAX_RET_CNT_C, para.batchSize),
-   m_drp(drp)
+    PgpReader(para, pool, std::min(MAX_RET_CNT_C, pool.dmaCount()), 32),
+    m_drp(drp)
 {
     if (pool.setMaskBytes(para.laneMask, det.virtChan)) {
         logging::critical("Failed to allocate lane/vc: '%m' "

--- a/psdaq/drp/PGPDetector.hh
+++ b/psdaq/drp/PGPDetector.hh
@@ -30,7 +30,7 @@ public:
     virtual void handleBrokenEvent(const PGPEvent& event) override;
     virtual void resetEventCounter() override;
 private:
-    static const int MAX_RET_CNT_C = 1000;
+    static const unsigned MAX_RET_CNT_C = 1000;
     PGPDrp& m_drp;
 };
 

--- a/psdaq/drp/PvaDetector.cc
+++ b/psdaq/drp/PvaDetector.cc
@@ -470,7 +470,7 @@ void PvMonitor::timeout(EbDgram* dgram)
 // ---
 
 Pgp::Pgp(const Parameters& para, MemPool& pool, Detector* det) :
-    PgpReader(para, pool, MAX_RET_CNT_C, 32),
+    PgpReader(para, pool, std::min(MAX_RET_CNT_C, pool.dmaCount()), 32),
     m_det(det),
     m_available(0), m_current(0), m_nDmaRet(0)
 {

--- a/psdaq/drp/PvaDetector.hh
+++ b/psdaq/drp/PvaDetector.hh
@@ -28,7 +28,7 @@ public:
 private:
     Pds::EbDgram* _handle(uint32_t& evtIndex);
     Detector* m_det;
-    static const int MAX_RET_CNT_C = 100;
+    static const unsigned MAX_RET_CNT_C = 100;
     int32_t m_available;
     int32_t m_current;
     uint64_t m_nDmaRet;

--- a/psdaq/drp/UdpEncoder.cc
+++ b/psdaq/drp/UdpEncoder.cc
@@ -515,7 +515,7 @@ int UdpReceiver::reset()
 
 
 Pgp::Pgp(const UdpParameters& para, MemPool& pool, Detector* det) :
-    PgpReader(para, pool, MAX_RET_CNT_C, 32),
+    PgpReader(para, pool, std::min(MAX_RET_CNT_C, pool.dmaCount()), 32),
     m_det(det),
     m_available(0), m_current(0), m_nDmaRet(0)
 {

--- a/psdaq/drp/UdpEncoder.hh
+++ b/psdaq/drp/UdpEncoder.hh
@@ -125,7 +125,7 @@ public:
 private:
     Pds::EbDgram* _handle(uint32_t& evtIndex);
     Detector* m_det;
-    static const int MAX_RET_CNT_C = 100;
+    static const unsigned MAX_RET_CNT_C = 100;
     int32_t m_available;
     int32_t m_current;
     uint64_t m_nDmaRet;

--- a/psdaq/epicsArch/EpicsArch.hh
+++ b/psdaq/epicsArch/EpicsArch.hh
@@ -19,11 +19,11 @@ public:
     const uint64_t nDmaRet() const { return m_nDmaRet; }
 private:
     Pds::EbDgram* _handle(uint32_t& evtIndex);
-    Detector*        m_det;
-    static const int MAX_RET_CNT_C = 100;
-    int32_t          m_available;
-    int32_t          m_current;
-    uint64_t         m_nDmaRet;
+    Detector*             m_det;
+    static const unsigned MAX_RET_CNT_C = 100;
+    int32_t               m_available;
+    int32_t               m_current;
+    uint64_t              m_nDmaRet;
 };
 
 

--- a/psdaq/epicsArch/epicsArch.cc
+++ b/psdaq/epicsArch/epicsArch.cc
@@ -32,7 +32,7 @@ using ms_t = std::chrono::milliseconds;
 namespace Drp {
 
 Pgp::Pgp(const Parameters& para, MemPool& pool, Detector* det) :
-    PgpReader(para, pool, MAX_RET_CNT_C, 32),
+    PgpReader(para, pool, std::min(MAX_RET_CNT_C, pool.dmaCount()), 32),
     m_det(det),
     m_available(0), m_current(0), m_nDmaRet(0)
 {


### PR DESCRIPTION
DMA buffers are freed in batches.  Batches were being configured to allow `MAX_RET_CNT_C` entries but the threshold used for freeing those entries came from a separate variable.  The unused batch entries were just wasted space.  A sanity check to ensure that the batch could get filled to the threshold could fail since the wrong value for the threshold was being used.  This was triggered by low DMA buffer counts (datadev driver `cfgRxCount` parameter). 
With the above fixed, it turned out that the `dmaReadBulkIndex()` datadev driver API call would not accept a bulk size (`MAX_RET_CNT_C`) greater than the number of configured DMA buffers (`cfgRxCount`).  The adopted solution was to take the minimum of the two values.  `dmaReadBulkIndex()` can thus now return all configured DMA buffers on a given call in low buffer count situations.