### PR TITLE
Add workflow_dispatch trigger to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 jobs:
   build_wheels:


### PR DESCRIPTION
Lets us manually run the wheel build/release workflow to verify the SHA-pinning fix without cutting a new release tag. The publish job's existing tag-push guard keeps a manual run from touching PyPI/GitHub releases.


Claude-Session: https://claude.ai/code/session_015AUhrMuM4H2EfrNepsc4jo