### PR TITLE
Install krb5-devel in manylinux before-all for pykerberos build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,14 @@ jobs:
           # default here instead of touching pyproject.toml's local-build
           # config.
           CIBW_CONTAINER_ENGINE: docker
+          # Matches run_psana_tests.yaml/run_daq_tests.yaml's job-level
+          # LCLS_CALIB_HTTP override. Several tests below fetch calibration
+          # constants; without this they hit CalibConstants.py's default,
+          # psdmint.sdf.slac.stanford.edu, which is SDF-internal and
+          # unreachable from a GitHub-hosted runner. cibuildwheel runs
+          # CIBW_TEST_COMMAND inside an isolated container, so this must be
+          # passed via CIBW_ENVIRONMENT_LINUX rather than plain job env.
+          CIBW_ENVIRONMENT_LINUX: LCLS_CALIB_HTTP=https://pswww.slac.stanford.edu/calib_ws/
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: >
             pytest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,12 @@ jobs:
           # unreachable from a GitHub-hosted runner. cibuildwheel runs
           # CIBW_TEST_COMMAND inside an isolated container, so this must be
           # passed via CIBW_ENVIRONMENT_LINUX rather than plain job env.
-          CIBW_ENVIRONMENT_LINUX: LCLS_CALIB_HTTP=https://pswww.slac.stanford.edu/calib_ws/
+          # NOTE: this env var *fully replaces* pyproject.toml's
+          # [tool.cibuildwheel.linux].environment table (cibuildwheel env
+          # vars override TOML entirely, they don't merge) -- so
+          # LD_LIBRARY_PATH from that table must be repeated here too, or
+          # mpi4py's dlopen fix silently disappears on GitHub Actions.
+          CIBW_ENVIRONMENT_LINUX: LD_LIBRARY_PATH=/usr/lib64/openmpi/lib:$LD_LIBRARY_PATH LCLS_CALIB_HTTP=https://pswww.slac.stanford.edu/calib_ws/
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: >
             pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,7 +173,10 @@ container-engine = { name = "podman", create-args = ["--cgroups=disabled", "--cg
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux_2_28"
 before-all = [
-    "dnf install -y libcurl-devel",
+    # krb5-devel provides gssapi/gssapi.h, needed to compile pykerberos
+    # (a lcls-krtc dependency) when cibuildwheel's test step installs
+    # the built wheel.
+    "dnf install -y libcurl-devel krb5-devel",
     # RapidJSON GCC-14 fix.
     "curl -sL https://github.com/Tencent/rapidjson/archive/24b5e7a8b27f42fa16b96fc70aade9106cf7102f.tar.gz | tar xz -C /tmp",
     "cp -r /tmp/rapidjson-24b5e7a8b27f42fa16b96fc70aade9106cf7102f/include/rapidjson /usr/include/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "psana"
 version="4.3"
-requires-python = ">=3.11"  # Source code supports Python 3.11+
+requires-python = ">=3.9"
 
 # Core dependencies.
 # Analysis excluded psdaq/ (not packaged in wheel, only built with build_daq=true)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,12 +175,16 @@ manylinux-x86_64-image = "manylinux_2_28"
 before-all = [
     # krb5-devel provides gssapi/gssapi.h, needed to compile pykerberos
     # (a lcls-krtc dependency) when cibuildwheel's test step installs
-    # the built wheel.
-    "dnf install -y libcurl-devel krb5-devel",
+    # the built wheel. openmpi provides the MPI runtime mpi4py needs to
+    # dlopen at import time (the wheel intentionally doesn't bundle it).
+    "dnf install -y libcurl-devel krb5-devel openmpi",
     # RapidJSON GCC-14 fix.
     "curl -sL https://github.com/Tencent/rapidjson/archive/24b5e7a8b27f42fa16b96fc70aade9106cf7102f.tar.gz | tar xz -C /tmp",
     "cp -r /tmp/rapidjson-24b5e7a8b27f42fa16b96fc70aade9106cf7102f/include/rapidjson /usr/include/",
 ]
+# openmpi's libmpi.so lands in a non-default lib path; mpi4py dlopens it
+# at import time and needs this to find it, both during build and test.
+environment = { LD_LIBRARY_PATH = "/usr/lib64/openmpi/lib:$LD_LIBRARY_PATH" }
 before-build = [
     # numpy install ordering rationale.
     "pip install meson ninja cython hatchling numpy",


### PR DESCRIPTION
release.yml's CIBW_TEST_COMMAND installs the built wheel, pulling in lcls-krtc -> pykerberos, which needs gssapi/gssapi.h to compile. That header isn't in the manylinux_2_28 image by default. Local Podman builds never hit this because pyproject.toml has no cibuildwheel test-command configured, so the wheel install/pykerberos compile never ran there.


