### PR TITLE
Trigger release workflow on any tag push, not just v*

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ name: Build wheels and create release
 on:
   push:
     tags:
-      - 'v*'
+      - '*'
   workflow_dispatch:
 
 jobs:
@@ -78,7 +78,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Gather build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8


### PR DESCRIPTION
The repo's version tags don't use a v prefix (e.g. 4.3.2), so the push.tags: 'v*' filter never matched and the workflow silently never started.


Claude-Session: https://claude.ai/code/session_019RjB9o2S48yqmcWnLmWAhh