### PR TITLE
Pin hatchling<1.32 and bump psana version to 4.3.3

### DIFF
--- a/psdaq/pyproject.toml
+++ b/psdaq/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling<1.32"]
 build-backend = "hatchling.build"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling<1.32"]
 build-backend = "hatchling.build"
 
 [project]
 name = "psana"
-version="4.3"
+version="4.3.3"
 requires-python = ">=3.9"
 
 # Core dependencies.


### PR DESCRIPTION
hatchling 1.32.0 bumped its default core-metadata version to 2.5, which the pinned pypa/gh-action-pypi-publish release action doesn't yet support, causing PyPI publish to fail with "InvalidDistribution: '2.5' is not a valid metadata version". Pin below that until the publish action catches up.

Also update psana's hardcoded version from 4.3 to 4.3.3 to match the release tag -- it wasn't being derived from the tag automatically.


